### PR TITLE
 Add support to property list details. (#79) [6.0]

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Symbol/PlistDetails.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/PlistDetails.swift
@@ -1,0 +1,41 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+extension SymbolGraph.Symbol {
+    
+    /// The details about a property list key.
+    public var plistDetails: PlistDetails? {
+        (mixins[PlistDetails.mixinKey] as? PlistDetails)
+    }
+    
+    /// A mixin that contains details about a property list key.
+    public struct PlistDetails: Mixin, Codable {
+        
+        public static let mixinKey = "plistDetails"
+        
+        /// The name of the key.
+        public var rawKey: String
+        /// A human-friendly name of the key.
+        public var customTitle: String?
+        /// The plain text name of a symbol's base type. For example, `Int` for an array of integers.
+        public var baseType: String?
+        /// Indicates if the base type is an array.
+        public var arrayMode: Bool?
+
+        public init(rawKey: String, customTitle: String? = nil, baseType: String? = nil, arrayMode: Bool? = false) {
+            self.arrayMode = arrayMode
+            self.baseType = baseType
+            self.customTitle = customTitle
+            self.rawKey = rawKey
+        }
+    }
+}

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -241,6 +241,7 @@ extension SymbolGraph.Symbol {
         static let httpParameterSource = HTTP.ParameterSource.symbolCodingInfo
         static let httpMediaType = HTTP.MediaType.symbolCodingInfo
         static let alternateDeclarations = AlternateDeclarations.symbolCodingInfo
+        static let plistDetails = PlistDetails.symbolCodingInfo
 
         static let mixinCodingInfo: [String: SymbolMixinCodingInfo] = [
             CodingKeys.availability.codingKey.stringValue: Self.availability,
@@ -266,6 +267,7 @@ extension SymbolGraph.Symbol {
             CodingKeys.httpParameterSource.codingKey.stringValue: Self.httpParameterSource,
             CodingKeys.httpMediaType.codingKey.stringValue: Self.httpMediaType,
             CodingKeys.alternateDeclarations.codingKey.stringValue: Self.alternateDeclarations,
+            CodingKeys.plistDetails.codingKey.stringValue: Self.plistDetails
         ]
         
         static func == (lhs: SymbolGraph.Symbol.CodingKeys, rhs: SymbolGraph.Symbol.CodingKeys) -> Bool {

--- a/Tests/SymbolKitTests/SymbolGraph/Symbol/PlistDetailsTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/Symbol/PlistDetailsTests.swift
@@ -1,0 +1,58 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import SymbolKit
+
+final class PlistDetailsTests: XCTestCase {
+    
+    func testPlistDetailsCanBeDecoded() throws {
+        let jsonData = """
+          {
+            "accessLevel" : "public",
+            "identifier" : {
+              "interfaceLanguage" : "plist",
+              "precise" : "plist:Information_Property_List.plist"
+            },
+            "kind" : {
+              "displayName" : "Property List Key",
+               "identifier" : "typealias"
+            },
+            "names" : {
+              "navigator" : [
+                {
+                  "kind" : "identifier",
+                  "spelling" : "plist"
+                }
+              ],
+              "title" : "plist"
+            },
+            "pathComponents" : [
+              "Information-Property-List",
+              "plist"
+            ],
+            "plistDetails" : {
+              "arrayMode" : true,
+              "baseType" : "Information Property List",
+              "rawKey" : "info-plist"
+            }
+          }
+        """.data(using: .utf8)
+        
+        let decoder = JSONDecoder()
+        let symbol = try decoder.decode(SymbolGraph.Symbol.self, from: jsonData!)
+        
+        let plistDetails = try XCTUnwrap(symbol.plistDetails)
+        XCTAssertEqual(plistDetails.rawKey, "info-plist")
+        XCTAssertEqual(plistDetails.baseType, "Information Property List")
+        XCTAssertEqual(plistDetails.arrayMode, true)
+    }
+    
+}


### PR DESCRIPTION
**Explanation:** Adds`plistDetails` mixin created to store detail information about property list keys symbols.
**Scope:** New mixin to store optional data to document plist keys.
**Issue** :rdar://131539008
**Original PR:** https://github.com/swiftlang/swift-docc-symbolkit/pull/79
**Risk:** Low. 
**Testing**: Unit tests has been added to ensure the correct behavior.
**Reviewer:** @QuietMisdreavus 