### PR TITLE
add a separate overload-group calculation in the unified graph collector

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/SymbolGraph+Overloads.swift
+++ b/Sources/SymbolKit/SymbolGraph/SymbolGraph+Overloads.swift
@@ -36,6 +36,11 @@ extension SymbolGraph {
     /// relationships are created between the colliding symbols and the new overload group symbol.
     /// In addition, any existing relationships the original symbol had are also cloned for the
     /// overload group.
+    ///
+    /// > Warning: If you are processing this symbol graph into a ``GraphCollector``, using this
+    /// > method can lead to incorrectly grouped overloads. Use the `createOverloadGroups`
+    /// > parameter of ``GraphCollector/finishLoading(createOverloadGroups:)`` instead, which will
+    /// > perform overload grouping over all the collected graphs.
     public mutating func createOverloadGroupSymbols() {
         struct OverloadKey: Hashable {
             let path: [String]

--- a/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
@@ -88,6 +88,11 @@ extension GraphCollector {
         }
     }
 
+    /// Finalizes the collected symbol graphs, loading in extension symbol graphs and processing orphan relationships.
+    ///
+    /// - Parameter createOverloadGroups: Whether to create overload group symbols in the resulting unified symbol graphs.
+    ///   If overload groups were created in the individual symbol graphs, they will be automatically combined regardless of this setting.
+    /// - Returns: A tuple containing a map of module names to unified symbol graphs, and a map of module names to symbol graph locations.
     public func finishLoading(
         createOverloadGroups: Bool = false
     ) -> (unifiedGraphs: [String: UnifiedSymbolGraph], graphSources: [String: [GraphKind]]) {

--- a/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
@@ -88,14 +88,20 @@ extension GraphCollector {
         }
     }
 
-    public func finishLoading() -> (unifiedGraphs: [String: UnifiedSymbolGraph], graphSources: [String: [GraphKind]]) {
+    public func finishLoading(
+        createOverloadGroups: Bool = false
+    ) -> (unifiedGraphs: [String: UnifiedSymbolGraph], graphSources: [String: [GraphKind]]) {
         for (url, graph) in self.extensionGraphs {
             self.mergeSymbolGraph(graph, at: url, forceLoading: true)
         }
 
         for (_, graph) in self.unifiedGraphs {
             graph.collectOrphans()
-            graph.combineOverloadGroups()
+            if createOverloadGroups {
+                graph.createOverloadGroupSymbols()
+            } else {
+                graph.combineOverloadGroups()
+            }
         }
 
         return (self.unifiedGraphs, self.graphSources)

--- a/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbol.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbol.swift
@@ -69,6 +69,22 @@ extension UnifiedSymbolGraph {
         /// Like an individual symbol's mixins, the `String` key for each mixin is its ``Mixin/mixinKey``.
         public var unifiedMixins: [String: Mixin]
 
+        /// Initialize an empty symbol with the given identifier.
+        init(uniqueIdentifier: String) {
+            self.uniqueIdentifier = uniqueIdentifier
+            self.mainGraphSelectors = []
+            self.modules = [:]
+            self.kind = [:]
+            self.pathComponents = [:]
+            self.type = nil
+            self.names = [:]
+            self.docComment = [:]
+            self.accessLevel = [:]
+            self.isVirtual = [:]
+            self.mixins = [:]
+            self.unifiedMixins = [:]
+        }
+
         /// Initialize a combined symbol view from a single symbol.
         public init(fromSingleSymbol sym: SymbolGraph.Symbol, module: SymbolGraph.Module, isMainGraph: Bool) {
             let lang = sym.identifier.interfaceLanguage

--- a/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbolGraph+Overloads.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbolGraph+Overloads.swift
@@ -82,6 +82,13 @@ extension UnifiedSymbolGraph {
                 uniqueIdentifier: overloadGroupIdentifier,
                 withSelectorsFromSourceLanguage: overloadKey.interfaceLanguage)
 
+            overloadGroupSymbol.isVirtual = overloadGroupSymbol.isVirtual.mapValues({ _ in true })
+
+            for (selector, simplifiedDeclaration) in overloadGroupSymbol.overloadSubheadingFragments() {
+                overloadGroupSymbol.names[selector]?.navigator = simplifiedDeclaration
+                overloadGroupSymbol.names[selector]?.subHeading = simplifiedDeclaration
+            }
+
             self.symbols[overloadGroupIdentifier] = overloadGroupSymbol
             self.overloadGroupSymbols.insert(overloadGroupIdentifier)
 

--- a/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbolGraph+Overloads.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbolGraph+Overloads.swift
@@ -63,9 +63,13 @@ extension UnifiedSymbolGraph {
             })
         }
 
+        let defaultImplementationSymbols = Set(relationshipsByLanguage.values.flatMap({
+            $0.filter({ $0.kind == .defaultImplementationOf }).map(\.source)
+        }))
+
         // Calculate all the overload keys for the remaining symbols.
         let overloadData = Overloads()
-        for symbol in symbols.values {
+        for (identifier, symbol) in symbols where !defaultImplementationSymbols.contains(identifier) {
             overloadData.calculateOverloadGroups(forSymbol: symbol)
         }
 

--- a/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbolGraph+Overloads.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbolGraph+Overloads.swift
@@ -1,0 +1,164 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+/// A graph holding information about overloaded symbols in a ``UnifiedSymbolGraph``.
+class Overloads {
+    var overloadGroups: [OverloadKey: [UnifiedSymbolGraph.Symbol]] = [:]
+
+    func calculateOverloadGroups(forSymbol symbol: UnifiedSymbolGraph.Symbol) {
+        let interfaceLanguages = Set(symbol.allSelectors.map(\.interfaceLanguage))
+        let keys = interfaceLanguages.compactMap({ OverloadKey(fromUnifiedSymbol: symbol, interfaceLanguage: $0) })
+
+        for key in keys where key.kind.isOverloadableKind {
+            overloadGroups[key, default: []].append(symbol)
+        }
+    }
+}
+
+extension Overloads {
+    /// A key structure used to group overloaded symbols together.
+    struct OverloadKey: Hashable {
+        let interfaceLanguage: String
+        let path: [String]
+        let kind: SymbolGraph.Symbol.KindIdentifier
+
+        public init?(fromUnifiedSymbol symbol: UnifiedSymbolGraph.Symbol, interfaceLanguage: String) {
+            let kinds = Set(symbol.kind.filter({ $0.key.interfaceLanguage == interfaceLanguage }).values.map(\.identifier))
+            let paths = Set(symbol.pathComponents.filter({ $0.key.interfaceLanguage == interfaceLanguage }).values)
+
+            guard kinds.count == 1, paths.count == 1 else {
+                // If a symbol has different paths or different symbol kinds in its constituent
+                // symbol graphs, then it shouldn't participate in overloads.
+                return nil
+            }
+
+            self.interfaceLanguage = interfaceLanguage
+            self.kind = kinds.first!
+            self.path = paths.first!
+        }
+    }
+}
+
+extension UnifiedSymbolGraph {
+    func createOverloadGroupSymbols() {
+        // If the individual symbol graphs had overload groups created, clear them from the symbols
+        // and relationships listings before continuing.
+        if !self.overloadGroupsFromOriginalGraphs.isEmpty {
+            self.symbols = self.symbols.filter({ !self.overloadGroupsFromOriginalGraphs.contains($0.key) })
+            self.relationshipsByLanguage = self.relationshipsByLanguage.mapValues({ relationships in
+                relationships.filter({ relationship in
+                    !self.overloadGroupsFromOriginalGraphs.contains(relationship.source) &&
+                    !self.overloadGroupsFromOriginalGraphs.contains(relationship.target) &&
+                    relationship.kind != .overloadOf
+                })
+            })
+        }
+
+        // Calculate all the overload keys for the remaining symbols.
+        let overloadData = Overloads()
+        for symbol in symbols.values {
+            overloadData.calculateOverloadGroups(forSymbol: symbol)
+        }
+
+        for (overloadKey, var overloadedSymbols) in overloadData.overloadGroups where overloadedSymbols.count > 1 {
+            overloadedSymbols.sort(by: Symbol.sortForOverloads(
+                orderByDeclaration: overloadedSymbols.allSatisfy({
+                    !$0.declarationFragments.isEmpty
+                })))
+
+            let firstOverload = overloadedSymbols.first!
+            let overloadGroupIdentifier = firstOverload.uniqueIdentifier + SymbolGraph.Symbol.overloadGroupIdentifierSuffix
+            let overloadGroupSymbol = Symbol(
+                cloning: firstOverload,
+                uniqueIdentifier: overloadGroupIdentifier,
+                withSelectorsFromSourceLanguage: overloadKey.interfaceLanguage)
+
+            self.symbols[overloadGroupIdentifier] = overloadGroupSymbol
+            self.overloadGroupSymbols.insert(overloadGroupIdentifier)
+
+            var overloadSelectors: Set<Selector> = []
+            for overloadedSymbol in overloadedSymbols {
+                overloadSelectors.formUnion(overloadedSymbol.selectors(forLanguage: overloadKey.interfaceLanguage))
+            }
+
+            // Clone the relationships from the first overload and add them to the overload group
+            for selector in overloadSelectors {
+                var newRelationships = (relationshipsByLanguage[selector] ?? []).filter({
+                    $0.target == firstOverload.uniqueIdentifier || $0.source == firstOverload.uniqueIdentifier
+                }).map({ relationship in
+                    var relationship = relationship
+                    if relationship.source == firstOverload.uniqueIdentifier {
+                        relationship.source = overloadGroupIdentifier
+                    } else if relationship.target == firstOverload.uniqueIdentifier {
+                        relationship.target = overloadGroupIdentifier
+                    }
+                    return relationship
+                })
+
+                // Add in new relationships from the overloaded symbols to the overload group
+                for symbol in overloadedSymbols where symbol.allSelectors.contains(selector) {
+                    newRelationships.append(.init(
+                        source: symbol.uniqueIdentifier,
+                        target: overloadGroupIdentifier,
+                        kind: .overloadOf,
+                        targetFallback: nil))
+                }
+
+                if !newRelationships.isEmpty {
+                    relationshipsByLanguage[selector, default: []].append(contentsOf: newRelationships)
+                }
+            }
+
+            for overloadIndex in overloadedSymbols.indices {
+                let overloadedSymbol = overloadedSymbols[overloadIndex]
+
+                overloadedSymbol.unifiedMixins[SymbolGraph.Symbol.OverloadData.mixinKey] =
+                    SymbolGraph.Symbol.OverloadData(
+                        overloadGroupIdentifier: overloadGroupIdentifier,
+                        overloadGroupIndex: overloadIndex)
+            }
+        }
+    }
+}
+
+extension UnifiedSymbolGraph.Symbol {
+    convenience init(
+        cloning original: UnifiedSymbolGraph.Symbol,
+        uniqueIdentifier: String,
+        withSelectorsFromSourceLanguage sourceLanguage: String? = nil
+    ) {
+        self.init(uniqueIdentifier: uniqueIdentifier)
+
+        let selectors: [UnifiedSymbolGraph.Selector]
+        if let sourceLanguage = sourceLanguage {
+            selectors = original.selectors(forLanguage: sourceLanguage)
+        } else {
+            selectors = original.allSelectors
+        }
+
+        self.mainGraphSelectors = original.mainGraphSelectors.filter({ selectors.contains($0) })
+
+        self.modules = original.modules.filter({ selectors.contains($0.key) })
+        self.kind = original.kind.filter({ selectors.contains($0.key) })
+        self.pathComponents = original.pathComponents.filter({ selectors.contains($0.key) })
+        self.type = original.type
+        self.names = original.names.filter({ selectors.contains($0.key) })
+        self.docComment = original.docComment.filter({ selectors.contains($0.key) })
+        self.accessLevel = original.accessLevel.filter({ selectors.contains($0.key) })
+        self.isVirtual = original.isVirtual.filter({ selectors.contains($0.key) })
+        self.mixins = original.mixins.filter({ selectors.contains($0.key) })
+    }
+
+    func selectors(forLanguage language: String) -> [UnifiedSymbolGraph.Selector] {
+        self.allSelectors.filter({ $0.interfaceLanguage == language })
+    }
+}

--- a/Tests/SymbolKitTests/UnifiedGraph/UnifiedGraph+OverloadsTests.swift
+++ b/Tests/SymbolKitTests/UnifiedGraph/UnifiedGraph+OverloadsTests.swift
@@ -14,169 +14,169 @@ import Foundation
 
 class UnifiedGraphOverloadsTests: XCTestCase {
     func testUnifiedOverloadGroups() throws {
-        let unifiedGraph = try unifySymbolGraphs(
-            ("DemoKit-macos.symbols.json", makeOverloadsSymbolGraph(platform: "macosx", withOverloads: [1, 2]))
-        )
+        try assertOnOverloadsGraphs(
+            ("DemoKit-macos.symbols.json", platform: "macosx", withOverloads: [1, 2])
+        ) { unifiedGraph in
+            let overloadSymbols = [1, 2].map(\.asOverloadIdentifier)
+            let expectedOverloadGroupIdentifier = 1.asOverloadIdentifier + SymbolGraph.Symbol.overloadGroupIdentifierSuffix
 
-        let overloadSymbols = [1, 2].map(\.asOverloadIdentifier)
-        let expectedOverloadGroupIdentifier = 1.asOverloadIdentifier + SymbolGraph.Symbol.overloadGroupIdentifierSuffix
+            let allRelations = unifiedGraph.unifiedRelationships
 
-        let allRelations = unifiedGraph.unifiedRelationships
+            // Make sure that overloadOf relationships were added
+            let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
+            XCTAssertEqual(overloadRelations.count, 2)
+            XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
+            XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
 
-        // Make sure that overloadOf relationships were added
-        let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
-        XCTAssertEqual(overloadRelations.count, 2)
-        XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
-        XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
+            // Pull out the overload group's identifier and make sure that it exists
+            let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
+            XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+            XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
 
-        // Pull out the overload group's identifier and make sure that it exists
-        let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
-        XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-        XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
-
-        // Make sure that the individual overloads reference the overload group and their index properly
-        for overloadIndex in overloadSymbols.indices {
-            let overloadIdentifier = overloadSymbols[overloadIndex]
-            let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
-            let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
-            XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-            XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            // Make sure that the individual overloads reference the overload group and their index properly
+            for overloadIndex in overloadSymbols.indices {
+                let overloadIdentifier = overloadSymbols[overloadIndex]
+                let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
+                let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
+                XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+                XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            }
         }
     }
 
     func testUnifiedOverloadGroupsAcrossPlatforms() throws {
-        let unifiedGraph = try unifySymbolGraphs(
-            ("DemoKit-macos.symbols.json", makeOverloadsSymbolGraph(platform: "macosx", withOverloads: [1, 2])),
-            ("DemoKit-ios.symbols.json", makeOverloadsSymbolGraph(platform: "ios", withOverloads: [1, 2]))
-        )
+        try assertOnOverloadsGraphs(
+            ("DemoKit-macos.symbols.json", platform: "macosx", withOverloads: [1, 2]),
+            ("DemoKit-ios.symbols.json", platform: "ios", withOverloads: [1, 2])
+        ) { unifiedGraph in
+            let overloadSymbols = [1, 2].map(\.asOverloadIdentifier)
+            let expectedOverloadGroupIdentifier = 1.asOverloadIdentifier + SymbolGraph.Symbol.overloadGroupIdentifierSuffix
 
-        let overloadSymbols = [1, 2].map(\.asOverloadIdentifier)
-        let expectedOverloadGroupIdentifier = 1.asOverloadIdentifier + SymbolGraph.Symbol.overloadGroupIdentifierSuffix
+            let allRelations = unifiedGraph.unifiedRelationships
 
-        let allRelations = unifiedGraph.unifiedRelationships
+            // Make sure that overloadOf relationships were added
+            let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
+            XCTAssertEqual(overloadRelations.count, 2)
+            XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
+            XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
 
-        // Make sure that overloadOf relationships were added
-        let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
-        XCTAssertEqual(overloadRelations.count, 2)
-        XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
-        XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
+            // Pull out the overload group's identifier and make sure that it exists
+            let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
+            XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+            XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
 
-        // Pull out the overload group's identifier and make sure that it exists
-        let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
-        XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-        XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
-
-        // Make sure that the individual overloads reference the overload group and their index properly
-        for overloadIndex in overloadSymbols.indices {
-            let overloadIdentifier = overloadSymbols[overloadIndex]
-            let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
-            let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
-            XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-            XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            // Make sure that the individual overloads reference the overload group and their index properly
+            for overloadIndex in overloadSymbols.indices {
+                let overloadIdentifier = overloadSymbols[overloadIndex]
+                let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
+                let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
+                XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+                XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            }
         }
     }
 
     func testOnePlatformDoesntOverload() throws {
-        let unifiedGraph = try unifySymbolGraphs(
-            ("DemoKit-macos.symbols.json", makeOverloadsSymbolGraph(platform: "macosx", withOverloads: [1])),
-            ("DemoKit-ios.symbols.json", makeOverloadsSymbolGraph(platform: "ios", withOverloads: [1, 2]))
-        )
+        try assertOnOverloadsGraphs(
+            ("DemoKit-macos.symbols.json", platform: "macosx", withOverloads: [1]),
+            ("DemoKit-ios.symbols.json", platform: "ios", withOverloads: [1, 2])
+        ) { unifiedGraph in
+            let overloadSymbols = [1, 2].map(\.asOverloadIdentifier)
+            let expectedOverloadGroupIdentifier = 1.asOverloadIdentifier + SymbolGraph.Symbol.overloadGroupIdentifierSuffix
 
-        let overloadSymbols = [1, 2].map(\.asOverloadIdentifier)
-        let expectedOverloadGroupIdentifier = 1.asOverloadIdentifier + SymbolGraph.Symbol.overloadGroupIdentifierSuffix
+            let allRelations = unifiedGraph.unifiedRelationships
 
-        let allRelations = unifiedGraph.unifiedRelationships
+            // Make sure that overloadOf relationships were added
+            let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
+            XCTAssertEqual(overloadRelations.count, 2)
+            XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
+            XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
 
-        // Make sure that overloadOf relationships were added
-        let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
-        XCTAssertEqual(overloadRelations.count, 2)
-        XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
-        XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
+            // Pull out the overload group's identifier and make sure that it exists
+            let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
+            XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+            XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
 
-        // Pull out the overload group's identifier and make sure that it exists
-        let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
-        XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-        XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
-
-        // Make sure that the individual overloads reference the overload group and their index properly
-        for overloadIndex in overloadSymbols.indices {
-            let overloadIdentifier = overloadSymbols[overloadIndex]
-            let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
-            let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
-            XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-            XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            // Make sure that the individual overloads reference the overload group and their index properly
+            for overloadIndex in overloadSymbols.indices {
+                let overloadIdentifier = overloadSymbols[overloadIndex]
+                let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
+                let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
+                XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+                XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            }
         }
     }
 
     func testDisjointOverloadGroups() throws {
-        let unifiedGraph = try unifySymbolGraphs(
-            ("DemoKit-macos.symbols.json", makeOverloadsSymbolGraph(platform: "macosx", withOverloads: [1, 2])),
-            ("DemoKit-ios.symbols.json", makeOverloadsSymbolGraph(platform: "ios", withOverloads: [1, 3]))
-        )
+        try assertOnOverloadsGraphs(
+            ("DemoKit-macos.symbols.json", platform: "macosx", withOverloads: [1, 2]),
+            ("DemoKit-ios.symbols.json", platform: "ios", withOverloads: [1, 3])
+        ) { unifiedGraph in
+            let overloadSymbols = [1, 2, 3].map(\.asOverloadIdentifier)
+            let expectedOverloadGroupIdentifier = 1.asOverloadIdentifier + SymbolGraph.Symbol.overloadGroupIdentifierSuffix
 
-        let overloadSymbols = [1, 2, 3].map(\.asOverloadIdentifier)
-        let expectedOverloadGroupIdentifier = 1.asOverloadIdentifier + SymbolGraph.Symbol.overloadGroupIdentifierSuffix
+            let allRelations = unifiedGraph.unifiedRelationships
 
-        let allRelations = unifiedGraph.unifiedRelationships
+            // Make sure that overloadOf relationships were added
+            let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
+            XCTAssertEqual(overloadRelations.count, 3)
+            XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
+            XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
 
-        // Make sure that overloadOf relationships were added
-        let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
-        XCTAssertEqual(overloadRelations.count, 3)
-        XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
-        XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
+            // Pull out the overload group's identifier and make sure that it exists
+            let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
+            XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+            XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
 
-        // Pull out the overload group's identifier and make sure that it exists
-        let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
-        XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-        XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
-
-        // Make sure that the individual overloads reference the overload group and their index properly
-        for overloadIndex in overloadSymbols.indices {
-            let overloadIdentifier = overloadSymbols[overloadIndex]
-            let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
-            let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
-            XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-            XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            // Make sure that the individual overloads reference the overload group and their index properly
+            for overloadIndex in overloadSymbols.indices {
+                let overloadIdentifier = overloadSymbols[overloadIndex]
+                let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
+                let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
+                XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+                XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            }
         }
     }
 
     func testRemoveExtraOverloadGroups() throws {
-        let unifiedGraph = try unifySymbolGraphs(
-            ("DemoKit-macos.symbols.json", makeOverloadsSymbolGraph(platform: "macosx", withOverloads: [1, 2])),
-            ("DemoKit-ios.symbols.json", makeOverloadsSymbolGraph(platform: "ios", withOverloads: [2, 3]))
-        )
+        try assertOnOverloadsGraphs(
+            ("DemoKit-macos.symbols.json", platform: "macosx", withOverloads: [1, 2]),
+            ("DemoKit-ios.symbols.json", platform: "ios", withOverloads: [2, 3])
+        ) { unifiedGraph in
+            let overloadSymbols = [1, 2, 3].map(\.asOverloadIdentifier)
+            let expectedOverloadGroupIdentifier = 1.asOverloadIdentifier + SymbolGraph.Symbol.overloadGroupIdentifierSuffix
 
-        let overloadSymbols = [1, 2, 3].map(\.asOverloadIdentifier)
-        let expectedOverloadGroupIdentifier = 1.asOverloadIdentifier + SymbolGraph.Symbol.overloadGroupIdentifierSuffix
+            let allRelations = unifiedGraph.unifiedRelationships
 
-        let allRelations = unifiedGraph.unifiedRelationships
+            // Make sure that overloadOf relationships were added
+            let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
+            XCTAssertEqual(overloadRelations.count, 3)
+            XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
+            XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
 
-        // Make sure that overloadOf relationships were added
-        let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
-        XCTAssertEqual(overloadRelations.count, 3)
-        XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
-        XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
+            // Pull out the overload group's identifier and make sure that it exists
+            let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
+            XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+            XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
 
-        // Pull out the overload group's identifier and make sure that it exists
-        let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
-        XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-        XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
+            // Make sure that the individual overloads reference the overload group and their index properly
+            for overloadIndex in overloadSymbols.indices {
+                let overloadIdentifier = overloadSymbols[overloadIndex]
+                let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
+                let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
+                XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+                XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            }
 
-        // Make sure that the individual overloads reference the overload group and their index properly
-        for overloadIndex in overloadSymbols.indices {
-            let overloadIdentifier = overloadSymbols[overloadIndex]
-            let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
-            let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
-            XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-            XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            // Also make sure that the iOS overload group was dropped from the unified graph
+            let iOSOverloadGroupIdentifier = 2.asOverloadIdentifier + SymbolGraph.Symbol.overloadGroupIdentifierSuffix
+            XCTAssertFalse(unifiedGraph.symbols.keys.contains(iOSOverloadGroupIdentifier))
+            XCTAssertFalse(allRelations.contains(where: {
+                $0.target == iOSOverloadGroupIdentifier || $0.source == iOSOverloadGroupIdentifier
+            }))
         }
-
-        // Also make sure that the iOS overload group was dropped from the unified graph
-        let iOSOverloadGroupIdentifier = 2.asOverloadIdentifier + SymbolGraph.Symbol.overloadGroupIdentifierSuffix
-        XCTAssertFalse(unifiedGraph.symbols.keys.contains(iOSOverloadGroupIdentifier))
-        XCTAssertFalse(allRelations.contains(where: {
-            $0.target == iOSOverloadGroupIdentifier || $0.source == iOSOverloadGroupIdentifier
-        }))
     }
 
     func testOverloadsWithSameDeclaration() throws {
@@ -184,8 +184,8 @@ class UnifiedGraphOverloadsTests: XCTestCase {
         // func myFunc()
         // (In a real-world scenario, these might differ by the swiftGenerics mixin, but here we can
         // write a contrived situation like this)
-        let unifiedGraph = try unifySymbolGraphs(
-            ("DemoKit.symbols.json", makeSymbolGraph(
+        try assertOnUnifiedGraphs(
+            ("DemoKit.symbols.json",
                 platform: "macosx",
                 symbols: [
                     .init(
@@ -215,35 +215,35 @@ class UnifiedGraphOverloadsTests: XCTestCase {
                                 ])
                         ]),
                 ],
-                relations: []))
-        )
+                relations: [])
+        ) { unifiedGraph in
+            let overloadSymbols = [
+                "s:myFunc-1",
+                "s:myFunc-2",
+            ]
+            let expectedOverloadGroupIdentifier = "s:myFunc-1::OverloadGroup"
 
-        let overloadSymbols = [
-            "s:myFunc-1",
-            "s:myFunc-2",
-        ]
-        let expectedOverloadGroupIdentifier = "s:myFunc-1::OverloadGroup"
+            let allRelations = unifiedGraph.unifiedRelationships
 
-        let allRelations = unifiedGraph.unifiedRelationships
+            // Make sure that overloadOf relationships were added
+            let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
+            XCTAssertEqual(overloadRelations.count, 2)
+            XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
+            XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
 
-        // Make sure that overloadOf relationships were added
-        let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
-        XCTAssertEqual(overloadRelations.count, 2)
-        XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
-        XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
+            // Pull out the overload group's identifier and make sure that it exists
+            let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
+            XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+            XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
 
-        // Pull out the overload group's identifier and make sure that it exists
-        let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
-        XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-        XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
-
-        // Make sure that the individual overloads reference the overload group and their index properly
-        for overloadIndex in overloadSymbols.indices {
-            let overloadIdentifier = overloadSymbols[overloadIndex]
-            let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
-            let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
-            XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-            XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            // Make sure that the individual overloads reference the overload group and their index properly
+            for overloadIndex in overloadSymbols.indices {
+                let overloadIdentifier = overloadSymbols[overloadIndex]
+                let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
+                let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
+                XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+                XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            }
         }
     }
 
@@ -252,8 +252,8 @@ class UnifiedGraphOverloadsTests: XCTestCase {
         // has an attribute in its declaration that causes it to sort above the other one. Make sure
         // that we correctly sort it to the top in the unified graph even when the iOS version sorts
         // `myFunc()-1` on top.
-        let unifiedGraph = try unifySymbolGraphs(
-            ("DemoKit-macos.symbols.json", makeSymbolGraph(
+        try assertOnUnifiedGraphs(
+            ("DemoKit-macos.symbols.json",
                 platform: "macosx",
                 symbols: [
                     .init(
@@ -283,8 +283,8 @@ class UnifiedGraphOverloadsTests: XCTestCase {
                                 ])
                         ]),
                 ],
-                relations: [])),
-            ("DemoKit-ios.symbols.json", makeSymbolGraph(
+                relations: []),
+            ("DemoKit-ios.symbols.json",
                 platform: "ios",
                 symbols: [
                     .init(
@@ -314,49 +314,49 @@ class UnifiedGraphOverloadsTests: XCTestCase {
                                 ])
                         ]),
                 ],
-                relations: []))
-        )
+                relations: [])
+        ) { unifiedGraph in
+            let overloadSymbols = [
+                "s:myFunc-2",
+                "s:myFunc-1",
+            ]
+            let expectedOverloadGroupIdentifier = "s:myFunc-2::OverloadGroup"
 
-        let overloadSymbols = [
-            "s:myFunc-2",
-            "s:myFunc-1",
-        ]
-        let expectedOverloadGroupIdentifier = "s:myFunc-2::OverloadGroup"
+            let allRelations = unifiedGraph.unifiedRelationships
 
-        let allRelations = unifiedGraph.unifiedRelationships
+            // Make sure that overloadOf relationships were added
+            let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
+            XCTAssertEqual(overloadRelations.count, 2)
+            XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
+            XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
 
-        // Make sure that overloadOf relationships were added
-        let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
-        XCTAssertEqual(overloadRelations.count, 2)
-        XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
-        XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
+            // Pull out the overload group's identifier and make sure that it exists
+            let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
+            XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+            XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
 
-        // Pull out the overload group's identifier and make sure that it exists
-        let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
-        XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-        XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
+            // Make sure that the individual overloads reference the overload group and their index properly
+            for overloadIndex in overloadSymbols.indices {
+                let overloadIdentifier = overloadSymbols[overloadIndex]
+                let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
+                let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
+                XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+                XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            }
 
-        // Make sure that the individual overloads reference the overload group and their index properly
-        for overloadIndex in overloadSymbols.indices {
-            let overloadIdentifier = overloadSymbols[overloadIndex]
-            let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
-            let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
-            XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-            XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            // Also make sure that the iOS overload group was dropped from the unified graph
+            let iOSOverloadGroupIdentifier = "s:myFunc-1::OverloadGroup"
+            XCTAssertFalse(unifiedGraph.symbols.keys.contains(iOSOverloadGroupIdentifier))
+            XCTAssertFalse(allRelations.contains(where: {
+                $0.target == iOSOverloadGroupIdentifier || $0.source == iOSOverloadGroupIdentifier
+            }))
         }
-
-        // Also make sure that the iOS overload group was dropped from the unified graph
-        let iOSOverloadGroupIdentifier = "s:myFunc-1::OverloadGroup"
-        XCTAssertFalse(unifiedGraph.symbols.keys.contains(iOSOverloadGroupIdentifier))
-        XCTAssertFalse(allRelations.contains(where: {
-            $0.target == iOSOverloadGroupIdentifier || $0.source == iOSOverloadGroupIdentifier
-        }))
     }
 
     /// Ensure that overload groups continue to sort overloads by identifier when both overloads are deprecated.
     func testDeprecatedOverloads() throws {
-        let unifiedGraph = try unifySymbolGraphs(
-            ("DemoKit.symbols.json", makeSymbolGraph(
+        try assertOnUnifiedGraphs(
+            ("DemoKit.symbols.json",
                 platform: "macosx",
                 symbols: [
                     .init(
@@ -404,43 +404,43 @@ class UnifiedGraphOverloadsTests: XCTestCase {
                                 ])
                         ]),
                 ],
-                relations: []))
-        )
+                relations: [])
+        ) { unifiedGraph in
+            let overloadSymbols = [
+                "s:myFunc-1",
+                "s:myFunc-2",
+            ]
+            let expectedOverloadGroupIdentifier = "s:myFunc-1::OverloadGroup"
 
-        let overloadSymbols = [
-            "s:myFunc-1",
-            "s:myFunc-2",
-        ]
-        let expectedOverloadGroupIdentifier = "s:myFunc-1::OverloadGroup"
+            let allRelations = unifiedGraph.unifiedRelationships
 
-        let allRelations = unifiedGraph.unifiedRelationships
+            // Make sure that overloadOf relationships were added
+            let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
+            XCTAssertEqual(overloadRelations.count, 2)
+            XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
+            XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
 
-        // Make sure that overloadOf relationships were added
-        let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
-        XCTAssertEqual(overloadRelations.count, 2)
-        XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
-        XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
+            // Pull out the overload group's identifier and make sure that it exists
+            let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
+            XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+            XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
 
-        // Pull out the overload group's identifier and make sure that it exists
-        let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
-        XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-        XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
-
-        // Make sure that the individual overloads reference the overload group and their index properly
-        for overloadIndex in overloadSymbols.indices {
-            let overloadIdentifier = overloadSymbols[overloadIndex]
-            let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
-            let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
-            XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-            XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            // Make sure that the individual overloads reference the overload group and their index properly
+            for overloadIndex in overloadSymbols.indices {
+                let overloadIdentifier = overloadSymbols[overloadIndex]
+                let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
+                let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
+                XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+                XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            }
         }
     }
 
     /// Ensure that an overload group does not select a deprecated overload as the overload group
     /// when a non-deprecated overload is available.
     func testPartiallyDeprecatedOverloads() throws {
-        let unifiedGraph = try unifySymbolGraphs(
-            ("DemoKit.symbols.json", makeSymbolGraph(
+        try assertOnUnifiedGraphs(
+            ("DemoKit.symbols.json",
                 platform: "macosx",
                 symbols: [
                     .init(
@@ -474,42 +474,42 @@ class UnifiedGraphOverloadsTests: XCTestCase {
                         kind: .init(parsedIdentifier: .func, displayName: "Function"),
                         mixins: [:]),
                 ],
-                relations: []))
-        )
+                relations: [])
+        ) { unifiedGraph in
+            let overloadSymbols = [
+                "s:myFunc-2",
+                "s:myFunc-1",
+            ]
+            let expectedOverloadGroupIdentifier = "s:myFunc-2::OverloadGroup"
 
-        let overloadSymbols = [
-            "s:myFunc-2",
-            "s:myFunc-1",
-        ]
-        let expectedOverloadGroupIdentifier = "s:myFunc-2::OverloadGroup"
+            let allRelations = unifiedGraph.unifiedRelationships
 
-        let allRelations = unifiedGraph.unifiedRelationships
+            // Make sure that overloadOf relationships were added
+            let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
+            XCTAssertEqual(overloadRelations.count, 2)
+            XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
+            XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
 
-        // Make sure that overloadOf relationships were added
-        let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
-        XCTAssertEqual(overloadRelations.count, 2)
-        XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
-        XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
+            // Pull out the overload group's identifier and make sure that it exists
+            let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
+            XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+            XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
 
-        // Pull out the overload group's identifier and make sure that it exists
-        let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
-        XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-        XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
-
-        // Make sure that the individual overloads reference the overload group and their index properly
-        for overloadIndex in overloadSymbols.indices {
-            let overloadIdentifier = overloadSymbols[overloadIndex]
-            let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
-            let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
-            XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-            XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            // Make sure that the individual overloads reference the overload group and their index properly
+            for overloadIndex in overloadSymbols.indices {
+                let overloadIdentifier = overloadSymbols[overloadIndex]
+                let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
+                let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
+                XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+                XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            }
         }
     }
 
     /// Like the above, but ensure that the same behavior holds for "unconditionally deprecated" symbols.
     func testPartiallyUnconditionallyDeprecatedOverloads() throws {
-        let unifiedGraph = try unifySymbolGraphs(
-            ("DemoKit.symbols.json", makeSymbolGraph(
+        try assertOnUnifiedGraphs(
+            ("DemoKit.symbols.json",
                 platform: "macosx",
                 symbols: [
                     .init(
@@ -543,90 +543,123 @@ class UnifiedGraphOverloadsTests: XCTestCase {
                         kind: .init(parsedIdentifier: .func, displayName: "Function"),
                         mixins: [:]),
                 ],
-                relations: []))
-        )
+                relations: [])
+        ) { unifiedGraph in
+            let overloadSymbols = [
+                "s:myFunc-2",
+                "s:myFunc-1",
+            ]
+            let expectedOverloadGroupIdentifier = "s:myFunc-2::OverloadGroup"
 
-        let overloadSymbols = [
-            "s:myFunc-2",
-            "s:myFunc-1",
-        ]
-        let expectedOverloadGroupIdentifier = "s:myFunc-2::OverloadGroup"
+            let allRelations = unifiedGraph.unifiedRelationships
 
-        let allRelations = unifiedGraph.unifiedRelationships
+            // Make sure that overloadOf relationships were added
+            let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
+            XCTAssertEqual(overloadRelations.count, 2)
+            XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
+            XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
 
-        // Make sure that overloadOf relationships were added
-        let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
-        XCTAssertEqual(overloadRelations.count, 2)
-        XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
-        XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
+            // Pull out the overload group's identifier and make sure that it exists
+            let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
+            XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+            XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
 
-        // Pull out the overload group's identifier and make sure that it exists
-        let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
-        XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-        XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
-
-        // Make sure that the individual overloads reference the overload group and their index properly
-        for overloadIndex in overloadSymbols.indices {
-            let overloadIdentifier = overloadSymbols[overloadIndex]
-            let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
-            let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
-            XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-            XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            // Make sure that the individual overloads reference the overload group and their index properly
+            for overloadIndex in overloadSymbols.indices {
+                let overloadIdentifier = overloadSymbols[overloadIndex]
+                let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
+                let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
+                XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+                XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            }
         }
     }
 
     /// Ensure that a cross-platform overload group from an extension symbol graph properly cleans
     /// up overload groups and relationships in the unified graph.
     func testOverloadsFromExtensionGraphs() throws {
-        let unifiedGraph = try unifySymbolGraphs(
-            ("DemoKit-macos.symbols.json", makeOverloadsSymbolGraph(platform: "macosx", withOverloads: [])),
-            ("DemoKit-ios.symbols.json", makeOverloadsSymbolGraph(platform: "ios", withOverloads: [])),
-            ("OtherKit-macos@DemoKit.symbols.json", makeSymbolGraph(
-                platform: "macosx",
-                symbols: [1, 2].map(\.asOverloadSymbol),
-                relations: [1, 2].map(\.asOverloadRelationship)
-            )),
-            ("OtherKit-ios@DemoKit.symbols.json", makeSymbolGraph(
-                platform: "ios",
-                symbols: [2, 3].map(\.asOverloadSymbol),
-                relations: [2, 3].map(\.asOverloadRelationship)
-            ))
-        )
+        // Since this test mixes the `withOverloads` wrapper with plain symbol graphs, it doesn't
+        // use the assertion wrapper of the previous tests.
+        let unifiedGraphs = [
+            try unifySymbolGraphs(
+                ("DemoKit-macos.symbols.json", makeOverloadsSymbolGraph(platform: "macosx", withOverloads: [])),
+                ("DemoKit-ios.symbols.json", makeOverloadsSymbolGraph(platform: "ios", withOverloads: [])),
+                ("OtherKit-macos@DemoKit.symbols.json", makeSymbolGraph(
+                    platform: "macosx",
+                    symbols: [1, 2].map(\.asOverloadSymbol),
+                    relations: [1, 2].map(\.asOverloadRelationship)
+                )),
+                ("OtherKit-ios@DemoKit.symbols.json", makeSymbolGraph(
+                    platform: "ios",
+                    symbols: [2, 3].map(\.asOverloadSymbol),
+                    relations: [2, 3].map(\.asOverloadRelationship)
+                ))
+            ),
+            try unifySymbolGraphs(
+                createOverloadGroups: true,
+                ("DemoKit-macos.symbols.json", makeOverloadsSymbolGraph(
+                    platform: "macosx",
+                    withOverloads: [],
+                    createOverloadGroups: false
+                )),
+                ("DemoKit-ios.symbols.json", makeOverloadsSymbolGraph(
+                    platform: "ios",
+                    withOverloads: [],
+                    createOverloadGroups: false
+                )),
+                ("OtherKit-macos@DemoKit.symbols.json", makeSymbolGraph(
+                    platform: "macosx",
+                    createOverloadGroups: false,
+                    symbols: [1, 2].map(\.asOverloadSymbol),
+                    relations: [1, 2].map(\.asOverloadRelationship)
+                )),
+                ("OtherKit-ios@DemoKit.symbols.json", makeSymbolGraph(
+                    platform: "ios",
+                    createOverloadGroups: false,
+                    symbols: [2, 3].map(\.asOverloadSymbol),
+                    relations: [2, 3].map(\.asOverloadRelationship)
+                ))
+            )
+        ]
 
-        let overloadSymbols = [1, 2, 3].map(\.asOverloadIdentifier)
-        let expectedOverloadGroupIdentifier = 1.asOverloadIdentifier + SymbolGraph.Symbol.overloadGroupIdentifierSuffix
+        for unifiedGraph in unifiedGraphs {
+            let overloadSymbols = [1, 2, 3].map(\.asOverloadIdentifier)
+            let expectedOverloadGroupIdentifier = 1.asOverloadIdentifier + SymbolGraph.Symbol.overloadGroupIdentifierSuffix
 
-        let allRelations = unifiedGraph.unifiedRelationships
+            let allRelations = unifiedGraph.unifiedRelationships
 
-        // Make sure that overloadOf relationships were added
-        let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
-        XCTAssertEqual(overloadRelations.count, 3)
-        XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
-        XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
+            // Make sure that overloadOf relationships were added
+            let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
+            XCTAssertEqual(overloadRelations.count, 3)
+            XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
+            XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
 
-        // Pull out the overload group's identifier and make sure that it exists
-        let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
-        XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-        XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
+            // Pull out the overload group's identifier and make sure that it exists
+            let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
+            XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+            XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
 
-        // Make sure that the individual overloads reference the overload group and their index properly
-        for overloadIndex in overloadSymbols.indices {
-            let overloadIdentifier = overloadSymbols[overloadIndex]
-            let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
-            let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
-            XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
-            XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            // Make sure that the individual overloads reference the overload group and their index properly
+            for overloadIndex in overloadSymbols.indices {
+                let overloadIdentifier = overloadSymbols[overloadIndex]
+                let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
+                let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
+                XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+                XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+            }
+
+            // Also make sure that the iOS overload group was dropped from the unified graph
+            let iOSOverloadGroupIdentifier = 2.asOverloadIdentifier + SymbolGraph.Symbol.overloadGroupIdentifierSuffix
+            XCTAssertFalse(unifiedGraph.symbols.keys.contains(iOSOverloadGroupIdentifier))
+            XCTAssertFalse(allRelations.contains(where: {
+                $0.target == iOSOverloadGroupIdentifier || $0.source == iOSOverloadGroupIdentifier
+            }))
         }
-
-        // Also make sure that the iOS overload group was dropped from the unified graph
-        let iOSOverloadGroupIdentifier = 2.asOverloadIdentifier + SymbolGraph.Symbol.overloadGroupIdentifierSuffix
-        XCTAssertFalse(unifiedGraph.symbols.keys.contains(iOSOverloadGroupIdentifier))
-        XCTAssertFalse(allRelations.contains(where: {
-            $0.target == iOSOverloadGroupIdentifier || $0.source == iOSOverloadGroupIdentifier
-        }))
     }
 
     func testNonOverlappingOverloads() throws {
+        // This test verifies behavior that doesn't work when creating overload groups in individual
+        // symbol graphs, so it doesn't use the test abstraction of the previous tests.
         let unifiedGraph = try unifySymbolGraphs(
             createOverloadGroups: true,
             ("DemoKit-macos.symbols.json", makeOverloadsSymbolGraph(platform: "macosx", withOverloads: [1], createOverloadGroups: false)),
@@ -661,6 +694,8 @@ class UnifiedGraphOverloadsTests: XCTestCase {
     }
 
     func testNonOverlappingOverloadsWithIndividualOverloadGroups() throws {
+        // This test verifies behavior that doesn't work when creating overload groups in individual
+        // symbol graphs, so it doesn't use the test abstraction of the previous tests.
         func assertOverloadGroups(unifiedGraph: UnifiedSymbolGraph) throws {
             let overloadSymbols = [1, 2, 3, 4].map(\.asOverloadIdentifier)
             let expectedOverloadGroupIdentifier = 1.asOverloadIdentifier + SymbolGraph.Symbol.overloadGroupIdentifierSuffix
@@ -722,6 +757,10 @@ class UnifiedGraphOverloadsTests: XCTestCase {
     }
 
     func testUnifiedOverloadGroupHasSimplifiedDeclaration() throws {
+        // This test verifies that the unified symbol graph overloads code has the same behavior as
+        // the single symbol graph overloads code. The single symbol graph version is tested in
+        // `SymbolGraphOverloadsTests.testCreateOverloadWithSimplifiedDeclaration`.
+
         // func myFunc(paramOne one: Int, paramTwo two: Int) -> Int
         let symbolName = "myFunc(paramOne:paramTwo:)"
         let subHeading: [SymbolGraph.Symbol.DeclarationFragments.Fragment] = [
@@ -854,6 +893,10 @@ class UnifiedGraphOverloadsTests: XCTestCase {
     }
 
     func testProtocolDefaultImplementationDoesNotCreateOverloads() throws {
+        // This test verifies that the unified symbol graph overloads code has the same behavior as
+        // the single symbol graph overloads code. The single symbol graph version is tested in
+        // `SymbolGraphOverloadsTests.testDefaultImplementationDoesNotCreateAnOverloadGroup`.
+
         // protocol MyProtocol
         // - requirement someFunc()
         // - default implementation someFunc()
@@ -1017,7 +1060,7 @@ private func makeSymbolGraph(
 private func unifySymbolGraphs(
     moduleName: String = "DemoKit",
     createOverloadGroups: Bool = false,
-    _ graphs: (fileName: String, symbolGraph: SymbolGraph)...,
+    graphs: [(fileName: String, symbolGraph: SymbolGraph)],
     file: StaticString = #file,
     line: UInt = #line
 ) throws -> UnifiedSymbolGraph {
@@ -1028,4 +1071,133 @@ private func unifySymbolGraphs(
     return try XCTUnwrap(
         collector.finishLoading(createOverloadGroups: createOverloadGroups).unifiedGraphs[moduleName],
         file: file, line: line)
+}
+
+private func unifySymbolGraphs(
+    moduleName: String = "DemoKit",
+    createOverloadGroups: Bool = false,
+    _ graphs: (fileName: String, symbolGraph: SymbolGraph)...,
+    file: StaticString = #file,
+    line: UInt = #line
+) throws -> UnifiedSymbolGraph {
+    try unifySymbolGraphs(
+        moduleName: moduleName,
+        createOverloadGroups: createOverloadGroups,
+        graphs: graphs,
+        file: file,
+        line: line)
+}
+
+private func generateUnifiedGraphs(
+    moduleName: String = "DemoKit",
+    _ graphs: [(fileName: String, platform: String, symbols: [SymbolGraph.Symbol], relations: [SymbolGraph.Relationship])],
+    file: StaticString = #file,
+    line: UInt = #line
+) throws -> [UnifiedSymbolGraph] {
+    let graphsWithOverloads = graphs.map({ graph in
+        (fileName: graph.fileName, symbolGraph: makeSymbolGraph(
+            platform: graph.platform,
+            createOverloadGroups: true,
+            symbols: graph.symbols,
+            relations: graph.relations))
+    })
+    let graphsWithoutOverloads = graphs.map({ graph in
+        (fileName: graph.fileName, symbolGraph: makeSymbolGraph(
+            platform: graph.platform,
+            createOverloadGroups: false,
+            symbols: graph.symbols,
+            relations: graph.relations))
+    })
+
+    return [
+        try unifySymbolGraphs(
+            moduleName: moduleName,
+            createOverloadGroups: false,
+            graphs: graphsWithOverloads,
+            file: file,
+            line: line
+        ),
+        try unifySymbolGraphs(
+            moduleName: moduleName,
+            createOverloadGroups: true,
+            graphs: graphsWithoutOverloads,
+            file: file,
+            line: line
+        )
+    ]
+}
+
+private func generateOverloadsUnifiedGraphs(
+    moduleName: String = "DemoKit",
+    _ graphs: [(fileName: String, platform: String, withOverloads: [Int])],
+    file: StaticString = #file,
+    line: UInt = #line
+) throws -> [UnifiedSymbolGraph] {
+    let graphsWithOverloads = graphs.map({ graph in
+        (fileName: graph.fileName, symbolGraph: makeOverloadsSymbolGraph(
+            platform: graph.platform,
+            withOverloads: graph.withOverloads,
+            createOverloadGroups: true))
+    })
+    let graphsWithoutOverloads = graphs.map({ graph in
+        (fileName: graph.fileName, symbolGraph: makeOverloadsSymbolGraph(
+            platform: graph.platform,
+            withOverloads: graph.withOverloads,
+            createOverloadGroups: false))
+    })
+
+    return [
+        try unifySymbolGraphs(
+            moduleName: moduleName,
+            createOverloadGroups: false,
+            graphs: graphsWithOverloads,
+            file: file,
+            line: line
+        ),
+        try unifySymbolGraphs(
+            moduleName: moduleName,
+            createOverloadGroups: true,
+            graphs: graphsWithoutOverloads,
+            file: file,
+            line: line
+        )
+    ]
+}
+
+private func assertOnUnifiedGraphs(
+    moduleName: String = "DemoKit",
+    _ graphs: (fileName: String, platform: String, symbols: [SymbolGraph.Symbol], relations: [SymbolGraph.Relationship])...,
+    runAssertions: ((UnifiedSymbolGraph) throws -> Void),
+    file: StaticString = #file,
+    line: UInt = #line
+) throws {
+    let unifiedGraphs = try generateUnifiedGraphs(
+        moduleName: moduleName,
+        graphs,
+        file: file,
+        line: line
+    )
+
+    for graph in unifiedGraphs {
+        try runAssertions(graph)
+    }
+}
+
+private func assertOnOverloadsGraphs(
+    moduleName: String = "DemoKit",
+    _ graphs: (fileName: String, platform: String, withOverloads: [Int])...,
+    runAssertions: ((UnifiedSymbolGraph) throws -> Void),
+    file: StaticString = #file,
+    line: UInt = #line
+) throws {
+    let unifiedGraphs = try generateOverloadsUnifiedGraphs(
+        moduleName: moduleName,
+        graphs,
+        file: file,
+        line: line
+    )
+
+    for graph in unifiedGraphs {
+        try runAssertions(graph)
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://131639487

## Summary

This PR updates the unified symbol graph collector to optionally create overload groups separately from the previous iteration, where it combined pre-existing overload groups created on individual symbol graphs. To preserve API compatibility (and use outside of unified symbol graphs), the other mechanisms are preserved, but they suffer from a bug. When overloads are added in disjoint sets, whether from an extension or from alternate platforms, the old overload grouping code failed to combine them together. This updated code ensures that all overload groups reflect all of the available symbols, regardless of their source.

## Dependencies

None

## Testing

A companion PR on Swift-DocC will go more in-depth into testing. This PR contains additional automated tests that demonstrate the new behavior.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary