### PR TITLE
add visionOS as a valid platform name

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Platform.swift
+++ b/Sources/SymbolKit/SymbolGraph/Platform.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -60,6 +60,8 @@ extension SymbolGraph {
                 return SymbolGraph.Symbol.Availability.Domain.watchOS
             case "tvos":
                 return SymbolGraph.Symbol.Availability.Domain.tvOS
+            case "visionos":
+                return SymbolGraph.Symbol.Availability.Domain.visionOS
             case "linux":
                 return SymbolGraph.Symbol.Availability.Domain.linux
             default:

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Availability/Domain.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Availability/Domain.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -97,6 +97,16 @@ extension SymbolGraph.Symbol.Availability {
          An application extension for the Mac Catalyst platform.
          */
         public static let macCatalystAppExtension = "macCatalystAppExtension"
+
+        /**
+         The visionOS operating system.
+         */
+        public static let visionOS = "visionOS"
+
+        /**
+         An application extension for the visionOS operating system.
+         */
+        public static let visionOSAppExtension = "visionOSAppExtension"
 
         /**
          A Linux-based operating system, but not a specific distribution.

--- a/Tests/SymbolKitTests/SymbolGraph/PlatformTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/PlatformTests.swift
@@ -12,25 +12,48 @@ import XCTest
 import SymbolKit
 
 class PlatformTests: XCTestCase {
-    func testMacosIsValidOperatingSystem() {
-        let macosPlatform = SymbolGraph.Platform(
-            architecture: nil,
-            vendor: nil,
-            operatingSystem: SymbolGraph.OperatingSystem(name: "macos"),
-            environment: nil
-        )
-        
-        XCTAssertEqual(macosPlatform.name, "macOS", "'macos' should be a valid OS identifier.")
+    func testValidOperatingSystems() {
+        let testPairs: [(inputName: String, expectedName: String)] = [
+            ("macos", "macOS"),
+            ("macosx", "macOS"),
+            ("ios", "iOS"),
+            ("tvos", "tvOS"),
+            ("watchos", "watchOS"),
+            ("visionos", "visionOS"),
+            ("linux", "Linux"),
+        ]
+
+        for (inputName, expectedName) in testPairs {
+            let platform = SymbolGraph.Platform(
+                architecture: nil,
+                vendor: nil,
+                operatingSystem: .init(name: inputName),
+                environment: nil
+            )
+
+            XCTAssertEqual(platform.name, expectedName, "'\(inputName)' should be a valid OS identifier.")
+        }
     }
-    
-    func testMacosxIsValidOperatingSystem() {
-        let macosxPlatform = SymbolGraph.Platform(
+
+    func testInvalidOperatingSystemName() {
+        let platform = SymbolGraph.Platform(
             architecture: nil,
             vendor: nil,
-            operatingSystem: SymbolGraph.OperatingSystem(name: "macosx"),
+            operatingSystem: SymbolGraph.OperatingSystem(name: "invalidos"),
             environment: nil
         )
-        
-        XCTAssertEqual(macosxPlatform.name, "macOS", "'macosx' should be a valid OS identifier.")
+
+        XCTAssertEqual(platform.name, "Unsupported OS: invalidos")
+    }
+
+    func testMacCatalystName() {
+        let platform = SymbolGraph.Platform(
+            architecture: nil,
+            vendor: nil,
+            operatingSystem: SymbolGraph.OperatingSystem(name: "ios"),
+            environment: "macabi"
+        )
+
+        XCTAssertEqual(platform.name, "macCatalyst", "'ios' should return macCatalyst when set with 'macabi'.")
     }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://123091182

## Summary

This PR adds a new parsed platform name, `visionOS`, that can be returned from the `SymbolGraph.Platform.name` property when a symbol graph with an operating system name of `visionos` is handled.

## Dependencies

None

## Testing

Automated testing has been extended to ensure that the platform name loads correctly.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary