### PR TITLE
fix some warnings in check-source

### DIFF
--- a/bin/check-source
+++ b/bin/check-source
@@ -43,10 +43,9 @@ tmp=$(mktemp /tmp/.swift-docc-symbolkit-check-source_XXXXXX)
 for language in swift-or-c bash md-or-tutorial html docker; do
   declare -a matching_files
   declare -a exceptions
-  declare -a reader
-  exceptions=( )
+  declare reader
   matching_files=( -name '*' )
-  reader=head
+  reader="head"
   case "$language" in
       swift-or-c)
         exceptions=( -name 'Package*.swift')
@@ -81,7 +80,7 @@ EOF
       md-or-tutorial)
         exceptions=( -path "./.github/*.md")
         matching_files=( -name '*.md' -o -name '*.tutorial' )
-        reader=tail
+        reader="tail"
         cat > "$tmp" <<"EOF"
 <!-- Copyright (c) YEARS Apple Inc and the Swift Project authors. All Rights Reserved. -->
 EOF


### PR DESCRIPTION
Bug/issue #, if applicable: None

## Summary

Right now, the `bin/check-source` script emits a few `bin/check-source: line 136: exceptions[@]: unbound variable` warnings. This PR addresses these warnings and fixes some additional warnings reported by `shellcheck`.

## Dependencies

None

## Testing

Ensure no loss of functionality.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary