### PR TITLE
save mixins alongside declarations for symbol alternates

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Symbol/AlternateDeclarations.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/AlternateDeclarations.swift
@@ -83,6 +83,11 @@ extension SymbolGraph.Symbol {
                 self.mixins = symbol.mixins
             }
 
+            public init(declarationFragments: DeclarationFragments) {
+                self.docComment = nil
+                self.mixins = [DeclarationFragments.mixinKey: declarationFragments]
+            }
+
             /// Whether this alternate has no information and should be discarded.
             public var isEmpty: Bool {
                 docComment == nil && mixins.isEmpty
@@ -101,6 +106,10 @@ extension SymbolGraph.Symbol {
 
         public init(alternateSymbols: [AlternateSymbol]) {
             self.alternateSymbols = alternateSymbols
+        }
+
+        init(alternateDeclarations: AlternateDeclarations) {
+            self.alternateSymbols = alternateDeclarations.declarations.map({ .init(declarationFragments: $0) })
         }
 
         /// The list of alternate symbol information.

--- a/Sources/SymbolKit/SymbolGraph/Symbol/AlternateDeclarations.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/AlternateDeclarations.swift
@@ -15,6 +15,7 @@ extension SymbolGraph.Symbol {
     ///
     /// This mixin is created while a symbol graph is decoded, to hold ``DeclarationFragments-swift.struct``
     /// for symbols which share the same precise identifier.
+    @available(*, deprecated, message: "This type is now unused; alternate declaration information is stored in AlternateSymbols instead.")
     public struct AlternateDeclarations: Mixin, Codable {
         public static let mixinKey = "alternateDeclarations"
 
@@ -36,23 +37,112 @@ extension SymbolGraph.Symbol {
         }
     }
 
-    /// Convenience accessor to fetch alternate declarations for this symbol.
-    public var alternateDeclarations: [DeclarationFragments]? {
-        (mixins[AlternateDeclarations.mixinKey] as? AlternateDeclarations)?.declarations
+    /// A mixin to hold alternate symbol information for a symbol.
+    ///
+    /// This mixin is created while a symbol graph is decoded,
+    /// to hold distinct information for symbols with the same precise identifier.
+    public struct AlternateSymbols: Mixin, Codable {
+        public static let mixinKey = "alternateSymbols"
+
+        public struct AlternateSymbol: Codable {
+            /// The doc comment for the alternate symbol.
+            public let docComment: SymbolGraph.LineList?
+
+            /// The mixins for the alternate symbol.
+            public var mixins: [String: Mixin] = [:]
+
+            public init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: SymbolGraph.Symbol.CodingKeys.self)
+                self.docComment = try container.decodeIfPresent(SymbolGraph.LineList.self, forKey: .docComment)
+
+                for key in container.allKeys {
+                    guard let info = SymbolGraph.Symbol.CodingKeys.mixinCodingInfo[key.stringValue] ?? decoder.registeredSymbolMixins?[key.stringValue] else {
+                        continue
+                    }
+
+                    mixins[key.stringValue] = try info.decode(container)
+                }
+            }
+
+            public func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: SymbolGraph.Symbol.CodingKeys.self)
+
+                try container.encodeIfPresent(docComment, forKey: .docComment)
+
+                for (key, mixin) in mixins {
+                    guard let info = SymbolGraph.Symbol.CodingKeys.mixinCodingInfo[key] ?? encoder.registeredSymbolMixins?[key] else {
+                        continue
+                    }
+
+                    try info.encode(mixin, &container)
+                }
+            }
+
+            public init(symbol: SymbolGraph.Symbol) {
+                self.docComment = symbol.docComment
+                self.mixins = symbol.mixins
+            }
+
+            /// Whether this alternate has no information and should be discarded.
+            public var isEmpty: Bool {
+                docComment == nil && mixins.isEmpty
+            }
+
+            /// Convenience accessor to fetch declaration fragments from the mixins dictionary.
+            public var declarationFragments: DeclarationFragments? {
+                self.mixins[DeclarationFragments.mixinKey] as? DeclarationFragments
+            }
+
+            /// Convenience accessor to fetch function signature information from the mixins dictionary.
+            public var functionSignature: FunctionSignature? {
+                self.mixins[FunctionSignature.mixinKey] as? FunctionSignature
+            }
+        }
+
+        public init(alternateSymbols: [AlternateSymbol]) {
+            self.alternateSymbols = alternateSymbols
+        }
+
+        /// The list of alternate symbol information.
+        public var alternateSymbols: [AlternateSymbol]
     }
 
-    internal mutating func addAlternateDeclaration(_ declaration: DeclarationFragments) {
-        if var alternateDeclarations = mixins[AlternateDeclarations.mixinKey] as? AlternateDeclarations {
-            alternateDeclarations.declarations.append(declaration)
-            mixins[AlternateDeclarations.mixinKey] = alternateDeclarations
-        } else {
-            mixins[AlternateDeclarations.mixinKey] = AlternateDeclarations(declarations: [declaration])
-        }
+    /// Convenience accessor to fetch alternate declarations for this symbol.
+    public var alternateDeclarations: [DeclarationFragments]? {
+        alternateSymbols?.alternateSymbols.compactMap(\.declarationFragments)
+    }
+
+    /// Convenience accessor to fetch alternate symbol information.
+    ///
+    /// Returns `nil` if there were no alternate symbols found when decoding the symbol graph.
+    public var alternateSymbols: AlternateSymbols? {
+        mixins[AlternateSymbols.mixinKey] as? AlternateSymbols
+    }
+
+    /// Convenience accessor to fetch a specific mixin from this symbol's alternate symbols.
+    ///
+    /// Because the mixin key is inferred from the type parameter,
+    /// the easiest way to call this method is by assigning it to a variable with an appropriate type:
+    ///
+    /// ```swift
+    /// let alternateFunctionSignatures: [SymbolGraph.Symbol.FunctionSignature]? = symbol.alternateSymbolMixins()
+    /// ```
+    ///
+    /// If there are multiple alternate symbols and only some of them have the requested mixin,
+    /// any missing data is removed from the resulting array via a `compactMap`.
+    public func alternateSymbolMixins<M: Mixin>(mixinKey: String = M.mixinKey) -> [M]? {
+        alternateSymbols?.alternateSymbols.compactMap({ $0.mixins[mixinKey] as? M })
     }
 
     internal mutating func addAlternateDeclaration(from symbol: SymbolGraph.Symbol) {
-        if let declaration = symbol.mixins[DeclarationFragments.mixinKey] as? DeclarationFragments {
-            addAlternateDeclaration(declaration)
+        let alternate = AlternateSymbols.AlternateSymbol(symbol: symbol)
+        guard !alternate.isEmpty else { return }
+
+        if var alternateSymbols = mixins[AlternateSymbols.mixinKey] as? AlternateSymbols {
+            alternateSymbols.alternateSymbols.append(alternate)
+            mixins[AlternateSymbols.mixinKey] = alternateSymbols
+        } else {
+            mixins[AlternateSymbols.mixinKey] = AlternateSymbols(alternateSymbols: [alternate])
         }
     }
 }

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
@@ -240,7 +240,7 @@ extension SymbolGraph.Symbol {
         static let httpEndpoint = HTTP.Endpoint.symbolCodingInfo
         static let httpParameterSource = HTTP.ParameterSource.symbolCodingInfo
         static let httpMediaType = HTTP.MediaType.symbolCodingInfo
-        static let alternateDeclarations = AlternateDeclarations.symbolCodingInfo
+        static let alternateSymbols = AlternateSymbols.symbolCodingInfo
         static let plistDetails = PlistDetails.symbolCodingInfo
 
         static let mixinCodingInfo: [String: SymbolMixinCodingInfo] = [
@@ -266,7 +266,7 @@ extension SymbolGraph.Symbol {
             CodingKeys.httpEndpoint.codingKey.stringValue: Self.httpEndpoint,
             CodingKeys.httpParameterSource.codingKey.stringValue: Self.httpParameterSource,
             CodingKeys.httpMediaType.codingKey.stringValue: Self.httpMediaType,
-            CodingKeys.alternateDeclarations.codingKey.stringValue: Self.alternateDeclarations,
+            CodingKeys.alternateSymbols.codingKey.stringValue: Self.alternateSymbols,
             CodingKeys.plistDetails.codingKey.stringValue: Self.plistDetails
         ]
         

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
@@ -151,7 +151,15 @@ extension SymbolGraph {
             docComment = try container.decodeIfPresent(LineList.self, forKey: .docComment)
             accessLevel = try container.decode(AccessControl.self, forKey: .accessLevel)
             isVirtual = try container.decodeIfPresent(Bool.self, forKey: .isVirtual) ?? false
-            
+
+            // Special-case `alternateDeclarations` and decode it into `alternateSymbols`.
+            // Do this before the next loop so that if both `alternateDeclarations` and
+            // `alternateSymbols` are present, the latter takes priority.
+            if container.contains(AlternateDeclarations.symbolCodingInfo.codingKey) {
+                let alternateDeclarations = try container.decode(AlternateDeclarations.self, forKey: AlternateDeclarations.symbolCodingInfo.codingKey)
+                mixins[AlternateSymbols.mixinKey] = AlternateSymbols(alternateDeclarations: alternateDeclarations)
+            }
+
             for key in container.allKeys {
                 guard let info = CodingKeys.mixinCodingInfo[key.stringValue] ?? decoder.registeredSymbolMixins?[key.stringValue] else {
                     continue

--- a/Tests/SymbolKitTests/SymbolGraph/SymbolGraphTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/SymbolGraphTests.swift
@@ -64,8 +64,9 @@ class SymbolGraphTests: XCTestCase {
             fragment.kind == .externalParameter && fragment.spelling == "completionHandler"
         }))
 
-        // The async declaration should have been saved as an alternate declaration
-        let alternateDeclarations = try XCTUnwrap(symbol.alternateDeclarations)
+        // The async declaration should have been saved as an alternate symbol
+        let alternateSymbols = try XCTUnwrap(symbol.alternateSymbols)
+        let alternateDeclarations = try XCTUnwrap(alternateSymbols.alternateSymbols.compactMap(\.declarationFragments))
         XCTAssertEqual(alternateDeclarations.count, 1)
         let alternate = alternateDeclarations[0]
 
@@ -76,6 +77,19 @@ class SymbolGraphTests: XCTestCase {
         XCTAssertFalse(alternate.declarationFragments.contains(where: { fragment in
             fragment.kind == .externalParameter && fragment.spelling == "completionHandler"
         }))
+
+        let alternateFunctionSignatures = try XCTUnwrap(alternateSymbols.alternateSymbols.compactMap(\.functionSignature))
+        XCTAssertEqual(alternateFunctionSignatures.count, 1)
+        let alternateSignature = alternateFunctionSignatures[0]
+
+        XCTAssertEqual(alternateSignature.parameters.count, 0)
+        XCTAssertEqual(alternateSignature.returns, [
+            .init(
+                kind: .keyword,
+                spelling: "Any",
+                preciseIdentifier: nil
+            )
+        ])
     }
 }
 
@@ -99,6 +113,47 @@ let symbolWithCompletionBlock = """
       },
       "names" : {
         "title" : "something(completionHandler:)"
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "completion",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "completion"
+              },
+              {
+                "kind": "text",
+                "spelling": ": (("
+              },
+              {
+                "kind": "keyword",
+                "spelling": "Any"
+              },
+              {
+                "kind": "text",
+                "spelling": ") -> "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "Void",
+                "preciseIdentifier": "s:s4Voida"
+              },
+              {
+                "kind": "text",
+                "spelling": ")!"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Void",
+            "preciseIdentifier": "s:s4Voida"
+          }
+        ]
       },
       "declarationFragments" : [
         {
@@ -164,6 +219,14 @@ let symbolWithAsyncKeyword = """
       },
       "names" : {
         "title" : "something()"
+      },
+      "functionSignature": {
+        "returns": [
+          {
+            "kind": "keyword",
+            "spelling": "Any"
+          }
+        ]
       },
       "declarationFragments" : [
         {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://133767750

## Summary

The "alternate declarations" mechanism added in https://github.com/swiftlang/swift-docc-symbolkit/pull/60 only preserves the declaration fragments of an alternate symbol, but this can hide other information, for example the related `functionSignature` mixin that is now used by Swift-DocC to lint documentation. This PR updates the "alternate declarations" functionality to save all of a symbol's mixins and its doc comment when merging alternate symbols together.

## Dependencies

None

## Testing

This is a purely API change, so coverage is handled with automated tests. A forthcoming PR on Swift-DocC will use the new API.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary