### PR TITLE
Support platforms with unknown names

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Platform.swift
+++ b/Sources/SymbolKit/SymbolGraph/Platform.swift
@@ -65,7 +65,7 @@ extension SymbolGraph {
             case "linux":
                 return SymbolGraph.Symbol.Availability.Domain.linux
             default:
-                return "Unsupported OS: \(os)"
+                return os
             }
         }
 

--- a/Sources/SymbolKit/SymbolGraph/Platform.swift
+++ b/Sources/SymbolKit/SymbolGraph/Platform.swift
@@ -49,13 +49,10 @@ extension SymbolGraph {
             switch os {
             case "macosx", "macos":
                 return SymbolGraph.Symbol.Availability.Domain.macOS
+            case "ios" where environment == "macabi":
+                return SymbolGraph.Symbol.Availability.Domain.macCatalyst
             case "ios":
-                if environment == "macabi" {
-                    return SymbolGraph.Symbol.Availability.Domain.macCatalyst
-
-                } else {
-                    return SymbolGraph.Symbol.Availability.Domain.iOS
-                }
+                return SymbolGraph.Symbol.Availability.Domain.iOS
             case "watchos":
                 return SymbolGraph.Symbol.Availability.Domain.watchOS
             case "tvos":

--- a/Tests/SymbolKitTests/SymbolGraph/PlatformTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/PlatformTests.swift
@@ -56,4 +56,14 @@ class PlatformTests: XCTestCase {
 
         XCTAssertEqual(platform.name, "macCatalyst", "'ios' should return macCatalyst when set with 'macabi'.")
     }
+    
+    func testiOSName() {
+        let platform = SymbolGraph.Platform(
+            architecture: nil,
+            vendor: nil,
+            operatingSystem: SymbolGraph.OperatingSystem(name: "ios")
+        )
+
+        XCTAssertEqual(platform.name, "iOS", "'ios' should return macCatalyst when set with 'macabi'.")
+    }
 }

--- a/Tests/SymbolKitTests/SymbolGraph/PlatformTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/PlatformTests.swift
@@ -35,15 +35,15 @@ class PlatformTests: XCTestCase {
         }
     }
 
-    func testInvalidOperatingSystemName() {
+    func testUnknownOperatingSystemName() {
         let platform = SymbolGraph.Platform(
             architecture: nil,
             vendor: nil,
-            operatingSystem: SymbolGraph.OperatingSystem(name: "invalidos"),
+            operatingSystem: SymbolGraph.OperatingSystem(name: "unknown platform"),
             environment: nil
         )
 
-        XCTAssertEqual(platform.name, "Unsupported OS: invalidos")
+        XCTAssertEqual(platform.name, "unknown platform")
     }
 
     func testMacCatalystName() {


### PR DESCRIPTION
Bug/issue #, if applicable: 112033286

## Summary

This change removes the addition of the string `Unsupported OS:` to platform names that are not considered as known platforms. Known platforms are apple platforms + Linux.

DocC is being used to document REST APIs and other codebases outside of the initial ecosystem use case. Having this string was making Symbolkit platform names incompatible for use with this other documentation use cases.

## Dependencies

N/A

## Testing

1. Run unit tests.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary