### PR TITLE
adds support to correctly identify snippet symbolgraphs

### DIFF
--- a/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
@@ -58,11 +58,12 @@ extension GraphCollector {
     ///   - inputGraph: The symbol graph to merge in.
     ///   - url: The file name where the given symbol graph is located. Used to determine whether a symbol graph
     ///     contains primary symbols or extensions.
-    ///   - forceLoading: A Boolean value, that defaults to `false`, that indicates whether the graph is merged
-    ///     even though it is a `primary` symbol graph.
+    ///   - forceLoading: Whether or not to force processing an extension symbol graph.
     ///
-    /// If the symbol graph is the `primary` graph, this method ignore merging the graph if it isn't already
-    /// registered in the graph collector. To force the loading into the collector, set `forceLoading` to `true`.
+    /// By default, "extension" symbol graphs are held aside and not processed immediately, to allow for
+    /// the "primary" graph to be loaded first regardless of the order that symbol graphs are found.
+    /// The `forceLoading` parameter is set to `true` during ``finishLoading(createOverloadGroups:)``
+    /// so that extension symbol graphs are eventually loaded at the end.
     public func mergeSymbolGraph(_ inputGraph: SymbolGraph, at url: URL, forceLoading: Bool = false) {
         let (extendedModuleName, isMainSymbolGraph) = Self.moduleNameFor(inputGraph, at: url)
 

--- a/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
@@ -58,6 +58,11 @@ extension GraphCollector {
     ///   - inputGraph: The symbol graph to merge in.
     ///   - url: The file name where the given symbol graph is located. Used to determine whether a symbol graph
     ///     contains primary symbols or extensions.
+    ///   - forceLoading: A Boolean value, that defaults to `false`, that indicates whether the graph is merged
+    ///     even though it is a `primary` symbol graph.
+    ///
+    /// If the symbol graph is the `primary` graph, this method ignore merging the graph if it isn't already
+    /// registered in the graph collector. To force the loading into the collector, set `forceLoading` to `true`.
     public func mergeSymbolGraph(_ inputGraph: SymbolGraph, at url: URL, forceLoading: Bool = false) {
         let (extendedModuleName, isMainSymbolGraph) = Self.moduleNameFor(inputGraph, at: url)
 
@@ -126,7 +131,11 @@ extension GraphCollector {
     ///   - url: The file name where the symbol graph is located.
     /// - Returns: The name of the module described by `graph`, and whether the symbol graph is a "primary" symbol graph.
     public static func moduleNameFor(_ graph: SymbolGraph, at url: URL) -> (String, Bool) {
-        let isMainSymbolGraph = !url.lastPathComponent.contains("@")
+        // The Swift compiler generates symbol graph URLs that contain an `@` symbol to denote an
+        // extension to another modules.
+        // The snippet extractor generates symbol graph files without an `@` symbol and with the
+        // the metadata that indicates the module `isVirtual`.
+        let isMainSymbolGraph = !url.lastPathComponent.contains("@") && !graph.module.isVirtual
 
         let moduleName: String
         if isMainSymbolGraph {

--- a/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
@@ -141,7 +141,15 @@ extension GraphCollector {
         if isMainSymbolGraph {
             // For main symbol graphs, get the module name from the symbol graph's data
             moduleName = graph.module.name
+            return (moduleName, isMainSymbolGraph)
         } else {
+            // Non-main symbol graphs are not only extensions, but also snippets. The correct module name
+            // for snippets **is** in the graph itself - so in the case where the URl is referencing symbol graph
+            // generated from snippets, return the name from within the graph.
+            if url.lastPathComponent.contains("-snippets.symbols.json") {
+                return (graph.module.name, isMainSymbolGraph)
+            }
+            
             // For extension symbol graphs, derive the extended module's name from the file name.
             //
             // The per-symbol `extendedModule` value is the same as the main module for most symbols, so it's not a good way to find the name
@@ -156,7 +164,7 @@ extension GraphCollector {
             } else {
                 moduleName = fileName.split(separator: "@", maxSplits: 1).last.map({ String($0) })!
             }
+            return (moduleName, isMainSymbolGraph)
         }
-        return (moduleName, isMainSymbolGraph)
     }
 }

--- a/Tests/SymbolKitTests/UnifiedGraph/GraphCollectorTests.swift
+++ b/Tests/SymbolKitTests/UnifiedGraph/GraphCollectorTests.swift
@@ -150,6 +150,6 @@ class GraphCollectorTests: XCTestCase {
         
         let (snippetName, snippetIsMain) = GraphCollector.moduleNameFor(a_snippet, at: .init(fileURLWithPath: "A-snippets.symbols.json"))
         XCTAssertFalse(snippetIsMain)
-        XCTAssertEqual("A-snippets", snippetName)
+        XCTAssertEqual("A", snippetName)
     }
 }


### PR DESCRIPTION
- expanded documentatin on mergeSymbolGraph to describe the forceLoading
  parameter.
- updated the logic to use the lack of `@` and the `isVirtual` metadata
  to determine if a symbolgraph is the primary graph for that module.


resolves #88 

Snippet extension graphs being considered `primary` is the source of non-deterministic results in previewing documentation that include snippets (https://github.com/swiftlang/swift-docc/issues/1084). For the logic within swift-dock's SymbolGraphLoader, they should be considered `extension` graphs. Since the snippet symbol graph extractor doesn't generate an `@` in the file name of the graph, the logic is amended to look at the isVirtual metadata for the module, which is set to `true` for snippets.

I considered using the name generated by the snippet extractor, or doing some heuristic on the name the generator metadata, but after staring at the data for a while, the `SymbolGraph.module.isVirtual` seemed a more exact and lasting means of determining if a given symbol graph is "the main one" or not.