### PR TITLE
Improve the ergonomics of working with the `Symbol.Availability.Domain` constants

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Platform.swift
+++ b/Sources/SymbolKit/SymbolGraph/Platform.swift
@@ -46,27 +46,29 @@ extension SymbolGraph {
             guard let os = operatingSystem?.name else {
                 return nil
             }
-            switch os {
+            
+            let domain: Symbol.Availability.Domain
+            switch operatingSystem?.name {
             case "macosx", "macos":
-                return SymbolGraph.Symbol.Availability.Domain.macOS
+                domain = .macOS
             case "ios":
                 if environment == "macabi" {
-                    return SymbolGraph.Symbol.Availability.Domain.macCatalyst
-
+                    domain = .macCatalyst
                 } else {
-                    return SymbolGraph.Symbol.Availability.Domain.iOS
+                    domain = .iOS
                 }
             case "watchos":
-                return SymbolGraph.Symbol.Availability.Domain.watchOS
+                domain = .watchOS
             case "tvos":
-                return SymbolGraph.Symbol.Availability.Domain.tvOS
+                domain = .tvOS
             case "visionos":
-                return SymbolGraph.Symbol.Availability.Domain.visionOS
+                domain = .visionOS
             case "linux":
-                return SymbolGraph.Symbol.Availability.Domain.linux
+                domain = .linux
             default:
                 return "Unsupported OS: \(os)"
             }
+            return domain.rawValue
         }
 
         public init(architecture: String? = nil, vendor: String? = nil, operatingSystem: OperatingSystem? = nil, environment: String? = nil) {

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Availability/Domain.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Availability/Domain.swift
@@ -41,76 +41,76 @@ extension SymbolGraph.Symbol.Availability {
          in Swift, or availability applies to particular versions
          of Swift.
          */
-        public static let swift = "Swift"
+        public static let swift = Domain(rawValue: "Swift")
 
         /**
          The Swift Package Manager Package Description Format.
          */
-        public static let swiftPM = "SwiftPM"
+        public static let swiftPM = Domain(rawValue: "SwiftPM")
 
         /**
          Apple's macOS operating system.
          */
-        public static let macOS = "macOS"
+        public static let macOS = Domain(rawValue: "macOS")
 
         /**
          An application extension for the macOS operating system.
          */
-        public static let macOSAppExtension = "macOSAppExtension"
+        public static let macOSAppExtension = Domain(rawValue: "macOSAppExtension")
 
         /**
          The iOS operating system.
          */
-        public static let iOS = "iOS"
+        public static let iOS = Domain(rawValue: "iOS")
 
         /**
          An application extension for the iOS operating system.
          */
-        public static let iOSAppExtension = "iOSAppExtension"
+        public static let iOSAppExtension = Domain(rawValue: "iOSAppExtension")
 
         /**
          The watchOS operating system.
          */
-        public static let watchOS = "watchOS"
+        public static let watchOS = Domain(rawValue: "watchOS")
 
         /**
          An application extension for the watchOS operating system.
          */
-        public static let watchOSAppExtension = "watchOSAppExtension"
+        public static let watchOSAppExtension = Domain(rawValue: "watchOSAppExtension")
 
         /**
          The tvOS operating system.
          */
-        public static let tvOS = "tvOS"
+        public static let tvOS = Domain(rawValue: "tvOS")
 
         /**
          An application extension for the tvOS operating system.
          */
-        public static let tvOSAppExtension = "tvOSAppExtension"
+        public static let tvOSAppExtension = Domain(rawValue: "tvOSAppExtension")
 
         /**
          The Mac Catalyst platform.
          */
-        public static let macCatalyst = "macCatalyst"
+        public static let macCatalyst = Domain(rawValue: "macCatalyst")
 
         /**
          An application extension for the Mac Catalyst platform.
          */
-        public static let macCatalystAppExtension = "macCatalystAppExtension"
+        public static let macCatalystAppExtension = Domain(rawValue: "macCatalystAppExtension")
 
         /**
          The visionOS operating system.
          */
-        public static let visionOS = "visionOS"
+        public static let visionOS = Domain(rawValue: "visionOS")
 
         /**
          An application extension for the visionOS operating system.
          */
-        public static let visionOSAppExtension = "visionOSAppExtension"
+        public static let visionOSAppExtension = Domain(rawValue: "visionOSAppExtension")
 
         /**
          A Linux-based operating system, but not a specific distribution.
          */
-        public static let linux = "Linux"
+        public static let linux = Domain(rawValue: "Linux")
     }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This improves the ergonomics of creating `Symbol.Availability.Domain` values for known constants.

Currently, because the constants are string values, creating a domain value for a known domain looks like:
```swift
let domain = Symbol.Availability.Domain(rawValue: Symbol.Availability.Domain.macOS)
```
with these changes, creating the same domain value looks like:
```swift
let domain = Symbol.Availability.Domain.macOS
```

> [!WARNING]
> **This is an API breaking change**

I tried to avoid making API breaking changes here but I didn't really like any of the alternatives. The least bad workaround I could think of was:
```swift
public static let swiftDomain = Domain(rawValue: "Swift")
@available(*, deprecated, renamed: "swiftDomain", message: "Use 'swiftDomain' instead. This deprecated API will be removed after 6.2 is released")
public static let swift = "Swift"
```
What I don't like about it is that after the 6.2 release we're either going to have API that doesn't follow Swift's API Design Guidelines (because it repeats the type name in the property name) or we're going to have to deprecate it again to rename it back to just "swift".

I have some hopes that this API is nearly unused in practice because the current ergonomics are so bad that I'd expect that someone would have complained about it if anyone was using it.

## Dependencies

This doesn't depend on anything but it's a breaking change for other repos.

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary