### PR TITLE
don't use obsolete/deprecated/unavailable symbols as the main symbol

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/SymbolGraph.swift
+++ b/Sources/SymbolKit/SymbolGraph/SymbolGraph.swift
@@ -61,11 +61,11 @@ public struct SymbolGraph: Codable {
     }
 
     public static func _symbolToKeepInCaseOfPreciseIdentifierConflict(_ lhs: Symbol, _ rhs: Symbol) -> Symbol {
-        if lhs.declarationContainsAsyncKeyword() {
+        if lhs.declarationContainsAsyncKeyword() || lhs.isObsoleteDeprecatedOrUnavailable() {
             var result = rhs
             result.addAlternateDeclaration(from: lhs)
             return result
-        } else if rhs.declarationContainsAsyncKeyword() {
+        } else if rhs.declarationContainsAsyncKeyword() || rhs.isObsoleteDeprecatedOrUnavailable() {
             var result = lhs
             result.addAlternateDeclaration(from: rhs)
             return result
@@ -102,5 +102,14 @@ extension SymbolGraph.Symbol {
         return (mixins[DeclarationFragments.mixinKey] as? DeclarationFragments)?.declarationFragments.contains(where: { fragment in
             fragment.kind == .keyword && fragment.spelling == "async"
         }) == true
+    }
+
+    fileprivate func isObsoleteDeprecatedOrUnavailable() -> Bool {
+        return availability?.contains { availabilityItem in
+            availabilityItem.obsoletedVersion != nil
+                || availabilityItem.deprecatedVersion != nil
+                || availabilityItem.isUnconditionallyDeprecated
+                || availabilityItem.isUnconditionallyUnavailable
+        } == true
     }
 }

--- a/Tests/SymbolKitTests/SymbolGraph/SymbolGraphTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/SymbolGraphTests.swift
@@ -131,9 +131,9 @@ class SymbolGraphTests: XCTestCase {
         XCTAssertEqual(symbolGraph.symbols.count, 1, "Only one of the symbols should be decoded")
         let symbol = try XCTUnwrap(symbolGraph.symbols.values.first)
 
-        XCTAssertEqual(symbol.names.title, "init(named:in:compatibleWith:)")
+        XCTAssertEqual(symbol.names.title, "init(name:)")
         XCTAssertEqual(symbol.declarationFragments, [
-            .init(kind: .identifier, spelling: "init(named:in:compatibleWith:)", preciseIdentifier: nil)
+            .init(kind: .identifier, spelling: "init(name:)", preciseIdentifier: nil)
         ])
 
         // The obsolete declaration should have been saved as an alternate symbol
@@ -142,7 +142,7 @@ class SymbolGraphTests: XCTestCase {
         XCTAssertEqual(alternateDeclarations.count, 1)
         let alternate = alternateDeclarations[0]
         XCTAssertEqual(alternate.declarationFragments, [
-            .init(kind: .identifier, spelling: "init(named:inBundle:compatibleWithTraitCollection:)", preciseIdentifier: nil)
+            .init(kind: .identifier, spelling: "init(symbolWithName:)", preciseIdentifier: nil)
         ])
     }
 }
@@ -510,20 +510,20 @@ private let obsoleteSymbolOverload: String = """
     "displayName": "Initializer"
   },
   "identifier": {
-    "precise": "c:objc(cs)UIColor(cm)colorNamed:inBundle:compatibleWithTraitCollection:",
+    "precise": "c:MySymbol:symbolWithName:",
     "interfaceLanguage": "swift"
   },
   "pathComponents": [
-    "UIColor",
-    "init(named:inBundle:compatibleWithTraitCollection:)"
+    "MyClass",
+    "init(symbolWithName:)"
   ],
   "names": {
-    "title": "init(named:inBundle:compatibleWithTraitCollection:)",
+    "title": "init(symbolWithName:)",
   },
   "declarationFragments" : [
     {
       "kind" : "identifier",
-      "spelling" : "init(named:inBundle:compatibleWithTraitCollection:)"
+      "spelling" : "init(symbolWithName:)"
     }
   ],
   "accessLevel": "public",
@@ -533,7 +533,7 @@ private let obsoleteSymbolOverload: String = """
       "obsoleted": {
         "major": 3
       },
-      "renamed": "init(named:in:compatibleWith:)"
+      "renamed": "init(name:)"
     },
     {
       "domain": "iOS",
@@ -553,20 +553,20 @@ private let targetSymbolOverload: String = """
     "displayName": "Initializer"
   },
   "identifier": {
-    "precise": "c:objc(cs)UIColor(cm)colorNamed:inBundle:compatibleWithTraitCollection:",
+    "precise": "c:MySymbol:symbolWithName:",
     "interfaceLanguage": "swift"
   },
   "pathComponents": [
-    "UIColor",
-    "init(named:in:compatibleWith:)"
+    "MySymbol",
+    "init(name:)"
   ],
   "names": {
-    "title": "init(named:in:compatibleWith:)",
+    "title": "init(name:)",
   },
   "declarationFragments" : [
     {
       "kind" : "identifier",
-      "spelling" : "init(named:in:compatibleWith:)"
+      "spelling" : "init(name:)"
     }
   ],
   "accessLevel": "public",


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://138648876

## Summary

In rare scenarios, it's possible for an Objective-C symbol to be imported into Swift with two names: One with a direct translation of the parameter names, and one with a modified symbol name. The former is imported with an obsolete availability marker, with a `renamed` key that points to the latter. SymbolKit's current selection behavior for symbol alternates chooses the original name, since the declaration is longer than the modified version. This leads to an obsolete symbol being represented in the decoded symbol graph, even though there is a non-obsolete declaration available for that symbol.

This PR updates the alternate symbol selection to prefer symbols that are not obsolete, deprecated, or unavailable.

## Dependencies

None

## Testing

Unfortunately, i could not reproduce the scenario in a test project, so i can only assume there is a special-case somewhere for Apple's SDKs. The test data included in this PR is derived from the original issue.

The obsolete-alternate scenario can be observed by generating symbol graphs for Apple's UIKit framework:

```
xcrun swift-symbolgraph-extract -sdk "$(xcrun --sdk iphoneos --show-sdk-path)" -module-name UIKit -output-dir /path/to/symbols
```

Searching for symbols with a precise identifier of `c:objc(cs)UIColor(cm)colorNamed:inBundle:compatibleWithTraitCollection:` will reveal the symbols in question.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary