### PR TITLE
Change type of `userInfo` to support `[CodingUserInfoKey: any Sendable]`

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Relationship/Relationship.swift
+++ b/Sources/SymbolKit/SymbolGraph/Relationship/Relationship.swift
@@ -148,6 +148,9 @@ extension SymbolGraph.Relationship {
     /// or decode that type and thus skips such entries. Note that ``Mixin``s that occur on relationships
     /// in the default symbol graph format do not have to be registered!
     ///
+    /// `UserInfoValue` is the type of the value in `JSONEncoder.userInfo`. This is generic to support both `Any` and
+    /// `any Sendable` (rdar://145669600) and must be either of these two types.
+    ///
     /// - Parameter userInfo: A property which allows editing the `userInfo` member of the
     /// `Encoder`/`Decoder` protocol.
     /// - Parameter onEncodingError: Defines the behavior when an error occurs while encoding these types of ``Mixin``s.
@@ -155,10 +158,10 @@ extension SymbolGraph.Relationship {
     /// - Parameter onDecodingError: Defines the behavior when an error occurs while decoding these types of ``Mixin``s.
     /// Next to logging warnings, the function allows for either re-throwing the error,
     /// skipping the erroneous entry, or providing a default value.
-    public static func register<M: Sequence>(mixins mixinTypes: M,
-                                             to userInfo: inout [CodingUserInfoKey: Any],
-                                             onEncodingError: ((_ error: Error, _ mixin: Mixin) throws -> Void)?,
-                                             onDecodingError: ((_ error: Error) throws -> Mixin?)?) where M.Element == Mixin.Type {
+    public static func register<M: Sequence, UserInfoValue>(mixins mixinTypes: M,
+                                                            to userInfo: inout [CodingUserInfoKey: UserInfoValue],
+                                                            onEncodingError: ((_ error: Error, _ mixin: Mixin) throws -> Void)?,
+                                                            onDecodingError: ((_ error: Error) throws -> Mixin?)?) where M.Element == Mixin.Type {
         var registeredMixins = userInfo[.relationshipMixinKey] as? [String: RelationshipMixinCodingInfo] ?? [:]
             
         for type in mixinTypes {
@@ -172,8 +175,11 @@ extension SymbolGraph.Relationship {
             
             registeredMixins[type.mixinKey] = info
         }
-        
-        userInfo[.relationshipMixinKey] = registeredMixins
+
+        // FIXME: Remove the `UserInfoValue` generic parameter when we no longer need to build swift-docc-symbolkit in 
+        // a configuration that contains https://github.com/swiftlang/swift-foundation/pull/1169 but not
+        // https://github.com/swiftlang/swift/pull/79382.
+        userInfo[.relationshipMixinKey] = (registeredMixins as! UserInfoValue)
     }
 }
 

--- a/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
@@ -263,21 +263,27 @@ extension SymbolGraph.Symbol.KindIdentifier {
     ///
     /// If a type is not registered, language prefixes cannot be removed correctly.
     ///
+    /// `UserInfoValue` is the type of the value in `JSONEncoder.userInfo`. This is generic to support both `Any` and
+    /// `any Sendable` (rdar://145669600) and must be either of these two types.
+    ///
     /// - Note: Registering custom identifiers on your decoder is only necessary when working in an uncontrolled environment where
     /// other parts of your executable might be disturbed by your modifications to the symbol graph structure. If that is not the case, use
     /// ``SymbolGraph/Symbol/KindIdentifier/register(_:)``.
     ///
     /// - Parameter userInfo: A property which allows editing the `userInfo` member of the
     /// `Decoder` protocol.
-    public static func register<I: Sequence>(_ identifiers: I,
-                                             to userInfo: inout [CodingUserInfoKey: Any]) where I.Element == Self {
+    public static func register<I: Sequence, UserInfoValue>(_ identifiers: I,
+                                                            to userInfo: inout [CodingUserInfoKey: UserInfoValue]) where I.Element == Self {
         var registeredIdentifiers = userInfo[.symbolKindIdentifierKey] as? [String: SymbolGraph.Symbol.KindIdentifier] ?? [:]
             
         for identifier in identifiers {
             registeredIdentifiers[identifier.identifier] = identifier
         }
         
-        userInfo[.symbolKindIdentifierKey] = registeredIdentifiers
+        // FIXME: Remove the `UserInfoValue` generic parameter when we no longer need to build swift-docc-symbolkit in 
+        // a configuration that contains https://github.com/swiftlang/swift-foundation/pull/1169 but not
+        // https://github.com/swiftlang/swift/pull/79382.
+        userInfo[.symbolKindIdentifierKey] = (registeredIdentifiers as! UserInfoValue)
     }
 }
 


### PR DESCRIPTION
This fixes build failures for setups that have https://github.com/swiftlang/swift-foundation/pull/1169 but not https://github.com/swiftlang/swift/pull/79382.

rdar://145669600
