### PR TITLE
allow SemanticVersion prerelease field to be int or string

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/SemanticVersion.swift
+++ b/Sources/SymbolKit/SymbolGraph/SemanticVersion.swift
@@ -8,6 +8,36 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+fileprivate enum PreReleaseVersion: Decodable {
+    case `int`(Int)
+    case `string`(String)
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if let intValue = try? container.decode(Int.self) {
+            self = .int(intValue)
+        } else if let stringValue = try? container.decode(String.self) {
+            self = .string(stringValue)
+        } else {
+            throw DecodingError.typeMismatch(
+                Self.self,
+                .init(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Expected Int or String"))
+        }
+    }
+
+    var stringValue: String {
+        switch self {
+        case .int(let intValue):
+            return String(intValue)
+        case .string(let stringValue):
+            return stringValue
+        }
+    }
+}
+
 extension SymbolGraph {
     /// A [semantic version](https://semver.org).
     public struct SemanticVersion: Codable, Equatable, CustomStringConvertible {
@@ -51,7 +81,7 @@ extension SymbolGraph {
             major = try container.decode(Int.self, forKey: .major)
             minor = try container.decodeIfPresent(Int.self, forKey: .minor) ?? 0
             patch = try container.decodeIfPresent(Int.self, forKey: .patch) ?? 0
-            prerelease = try container.decodeIfPresent(String.self, forKey: .prerelease)
+            prerelease = try container.decodeIfPresent(PreReleaseVersion.self, forKey: .prerelease)?.stringValue
             buildMetadata = try container.decodeIfPresent(String.self, forKey: .buildMetadata)
         }
 

--- a/Tests/SymbolKitTests/SymbolGraph/LineList/SemanticVersionTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/LineList/SemanticVersionTests.swift
@@ -23,4 +23,57 @@ class SemanticVersionTests: XCTestCase {
         XCTAssertEqual(version.prerelease, "beta")
         XCTAssertEqual(version.buildMetadata, "enableX")
     }
+
+    func testDecodeSemanticVersionWithIntPreRelease() throws {
+        let inputJson: String = """
+        {
+          "major": 1,
+          "minor": 2,
+          "patch": 3,
+          "prerelease": 4
+        }
+        """
+
+        let version = try JSONDecoder().decode(SemanticVersion.self, from: inputJson.data(using: .utf8)!)
+
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 2)
+        XCTAssertEqual(version.patch, 3)
+        XCTAssertEqual(version.prerelease, "4")
+    }
+
+    func testDecodeSemanticVersionWithStringPreRelease() throws {
+        let inputJson: String = """
+        {
+          "major": 1,
+          "minor": 2,
+          "patch": 3,
+          "prerelease": "4"
+        }
+        """
+
+        let version = try JSONDecoder().decode(SemanticVersion.self, from: inputJson.data(using: .utf8)!)
+
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 2)
+        XCTAssertEqual(version.patch, 3)
+        XCTAssertEqual(version.prerelease, "4")
+    }
+
+    func testDecodeSemanticVersionWithNoPreRelease() throws {
+        let inputJson: String = """
+        {
+          "major": 1,
+          "minor": 2,
+          "patch": 3
+        }
+        """
+
+        let version = try JSONDecoder().decode(SemanticVersion.self, from: inputJson.data(using: .utf8)!)
+
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 2)
+        XCTAssertEqual(version.patch, 3)
+        XCTAssertNil(version.prerelease)
+    }
 }

--- a/bin/check-source
+++ b/bin/check-source
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][78901234]-20[12][8901234]/YEARS/' -e 's/20[12][8901234]/YEARS/'
+    sed -e 's/20[12][789012345]-20[12][89012345]/YEARS/' -e 's/20[12][89012345]/YEARS/'
 }
 
 printf "=> Checking for unacceptable language… "


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://147937598

## Summary

It turns out that the Swift symbol graph generator emits an integer field for the `prerelease` part of a version, if it's present. This causes a decoding error in SymbolKit, since it's expecting a string. This PR updates the `SemanticVersion` type to allow decoding JSON with either a string or an integer for the `prerelease` field.

## Dependencies

None

## Testing

This has been covered with automated tests.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary