### PR TITLE
Revert "Change type of `userInfo` to support `[CodingUserInfoKey: any Sendable]`"

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Relationship/Relationship.swift
+++ b/Sources/SymbolKit/SymbolGraph/Relationship/Relationship.swift
@@ -148,9 +148,6 @@ extension SymbolGraph.Relationship {
     /// or decode that type and thus skips such entries. Note that ``Mixin``s that occur on relationships
     /// in the default symbol graph format do not have to be registered!
     ///
-    /// `UserInfoValue` is the type of the value in `JSONEncoder.userInfo`. This is generic to support both `Any` and
-    /// `any Sendable` (rdar://145669600) and must be either of these two types.
-    ///
     /// - Parameter userInfo: A property which allows editing the `userInfo` member of the
     /// `Encoder`/`Decoder` protocol.
     /// - Parameter onEncodingError: Defines the behavior when an error occurs while encoding these types of ``Mixin``s.
@@ -158,10 +155,10 @@ extension SymbolGraph.Relationship {
     /// - Parameter onDecodingError: Defines the behavior when an error occurs while decoding these types of ``Mixin``s.
     /// Next to logging warnings, the function allows for either re-throwing the error,
     /// skipping the erroneous entry, or providing a default value.
-    public static func register<M: Sequence, UserInfoValue>(mixins mixinTypes: M,
-                                                            to userInfo: inout [CodingUserInfoKey: UserInfoValue],
-                                                            onEncodingError: ((_ error: Error, _ mixin: Mixin) throws -> Void)?,
-                                                            onDecodingError: ((_ error: Error) throws -> Mixin?)?) where M.Element == Mixin.Type {
+    public static func register<M: Sequence>(mixins mixinTypes: M,
+                                             to userInfo: inout [CodingUserInfoKey: Any],
+                                             onEncodingError: ((_ error: Error, _ mixin: Mixin) throws -> Void)?,
+                                             onDecodingError: ((_ error: Error) throws -> Mixin?)?) where M.Element == Mixin.Type {
         var registeredMixins = userInfo[.relationshipMixinKey] as? [String: RelationshipMixinCodingInfo] ?? [:]
             
         for type in mixinTypes {
@@ -175,11 +172,8 @@ extension SymbolGraph.Relationship {
             
             registeredMixins[type.mixinKey] = info
         }
-
-        // FIXME: Remove the `UserInfoValue` generic parameter when we no longer need to build swift-docc-symbolkit in 
-        // a configuration that contains https://github.com/swiftlang/swift-foundation/pull/1169 but not
-        // https://github.com/swiftlang/swift/pull/79382.
-        userInfo[.relationshipMixinKey] = (registeredMixins as! UserInfoValue)
+        
+        userInfo[.relationshipMixinKey] = registeredMixins
     }
 }
 

--- a/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
@@ -263,27 +263,21 @@ extension SymbolGraph.Symbol.KindIdentifier {
     ///
     /// If a type is not registered, language prefixes cannot be removed correctly.
     ///
-    /// `UserInfoValue` is the type of the value in `JSONEncoder.userInfo`. This is generic to support both `Any` and
-    /// `any Sendable` (rdar://145669600) and must be either of these two types.
-    ///
     /// - Note: Registering custom identifiers on your decoder is only necessary when working in an uncontrolled environment where
     /// other parts of your executable might be disturbed by your modifications to the symbol graph structure. If that is not the case, use
     /// ``SymbolGraph/Symbol/KindIdentifier/register(_:)``.
     ///
     /// - Parameter userInfo: A property which allows editing the `userInfo` member of the
     /// `Decoder` protocol.
-    public static func register<I: Sequence, UserInfoValue>(_ identifiers: I,
-                                                            to userInfo: inout [CodingUserInfoKey: UserInfoValue]) where I.Element == Self {
+    public static func register<I: Sequence>(_ identifiers: I,
+                                             to userInfo: inout [CodingUserInfoKey: Any]) where I.Element == Self {
         var registeredIdentifiers = userInfo[.symbolKindIdentifierKey] as? [String: SymbolGraph.Symbol.KindIdentifier] ?? [:]
             
         for identifier in identifiers {
             registeredIdentifiers[identifier.identifier] = identifier
         }
         
-        // FIXME: Remove the `UserInfoValue` generic parameter when we no longer need to build swift-docc-symbolkit in 
-        // a configuration that contains https://github.com/swiftlang/swift-foundation/pull/1169 but not
-        // https://github.com/swiftlang/swift/pull/79382.
-        userInfo[.symbolKindIdentifierKey] = (registeredIdentifiers as! UserInfoValue)
+        userInfo[.symbolKindIdentifierKey] = registeredIdentifiers
     }
 }
 

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
@@ -302,9 +302,6 @@ extension SymbolGraph.Symbol {
     /// or decode that type and thus skips such entries. Note that ``Mixin``s that occur on symbols
     /// in the default symbol graph format do not have to be registered!
     ///
-    /// `UserInfoValue` is the type of the value in `JSONEncoder.userInfo`. This is generic to support both `Any` and
-    /// `any Sendable` (rdar://145669600) and must be either of these two types.
-    ///
     /// - Parameter userInfo: A property which allows editing the `userInfo` member of the
     /// `Encoder`/`Decoder` protocol.
     /// - Parameter onEncodingError: Defines the behavior when an error occurs while encoding these types of ``Mixin``s.
@@ -312,10 +309,10 @@ extension SymbolGraph.Symbol {
     /// - Parameter onDecodingError: Defines the behavior when an error occurs while decoding these types of ``Mixin``s.
     /// Next to logging warnings, the function allows for either re-throwing the error,
     /// skipping the erroneous entry, or providing a default value.
-    public static func register<M: Sequence, UserInfoValue>(mixins mixinTypes: M,
-                                                            to userInfo: inout [CodingUserInfoKey: UserInfoValue],
-                                                            onEncodingError: ((_ error: Error, _ mixin: Mixin) throws -> Void)?,
-                                                            onDecodingError: ((_ error: Error) throws -> Mixin?)?)
+    public static func register<M: Sequence>(mixins mixinTypes: M,
+                                             to userInfo: inout [CodingUserInfoKey: Any],
+                                             onEncodingError: ((_ error: Error, _ mixin: Mixin) throws -> Void)?,
+                                             onDecodingError: ((_ error: Error) throws -> Mixin?)?)
     where M.Element == Mixin.Type {
         var registeredMixins = userInfo[.symbolMixinKey] as? [String: SymbolMixinCodingInfo] ?? [:]
             
@@ -331,10 +328,7 @@ extension SymbolGraph.Symbol {
             registeredMixins[type.mixinKey] = info
         }
         
-        // FIXME: Remove the `UserInfoValue` generic parameter when we no longer need to build swift-docc-symbolkit in 
-        // a configuration that contains https://github.com/swiftlang/swift-foundation/pull/1169 but not
-        // https://github.com/swiftlang/swift/pull/79382.
-        userInfo[.symbolMixinKey] = (registeredMixins as! UserInfoValue)
+        userInfo[.symbolMixinKey] = registeredMixins
     }
 }
 


### PR DESCRIPTION
Reverts swiftlang/swift-docc-symbolkit#96. 

All relevant setups that have https://github.com/swiftlang/swift-foundation/pull/1169 should have https://github.com/swiftlang/swift/pull/79382 by now.