### PR TITLE
add SwiftToolchain as a recognized availability domain

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Symbol/Availability/Domain.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Availability/Domain.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -42,6 +42,15 @@ extension SymbolGraph.Symbol.Availability {
          of Swift.
          */
         public static let swift = "Swift"
+
+        /**
+         The Swift toolchain release.
+
+         While ``swift`` indicates availability with respect to the required language mode,
+         this availability domain indicates which version of the Swift toolchain
+         a symbol was introduced in.
+         */
+        public static let swiftToolchain = "SwiftToolchain"
 
         /**
          The Swift Package Manager Package Description Format.


### PR DESCRIPTION
Bug/issue #, if applicable: None (though it is related to rdar://151390924)

## Summary

https://github.com/swiftlang/swift/pull/81715 introduces a new availability domain `_SwiftToolchain`, that is rendered into symbol graphs with the token `SwiftToolchain`. This PR adds a new static property to `Availability.Domain` that can be used to compare the received value.

## Dependencies

https://github.com/swiftlang/swift/pull/81715 (though they can be merged in any order)

## Testing

Complete testing will need to happen with integration in Swift-DocC (in a forthcoming PR)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary