### PR TITLE
add logic to properly handle cross-import overlay graphs

### DIFF
--- a/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
@@ -140,20 +140,15 @@ extension GraphCollector {
 
         let moduleName: String
         if isMainSymbolGraph || graph.module.bystanders != nil {
-            // graph.module.bystanders exist with cross-import overlays, and we return the module name
-            // from the data in that graph, rather than trying to extract it from the filename,
-            // but it isn't considered a "primary" graph.
+            // When bystander modules are present, the symbol graph is a cross-import overlay, and
+            // we need to preserve the original module name to properly render it. It is still
+            // kept with the extension symbols, due to the merging behavior of UnifiedSymbolGraph.
 
             // A cross-import overlays is a distinct module that references a “declaring module”
             // (the module it is considered to be a part of) and one or more “bystander modules”
             // (modules that must be imported alongside the declaring module for the overlay to be available)
-            // it allows a module to declare extensions to another module without having to import it
-            // directly, like how MapKit adds a SwiftUI view but doesn’t actually import SwiftUI itself.
-            // when a symbol graph is requested for a cross-import overlay module, it is treated as
-            // an extension symbol graph for the declaring module so that the symbols can be folded into
-            // there.
 
-            // For main symbol graphs, get the module name from the symbol graph's data
+            // For main symbol graphs (and cross-import overlays), get the module name from the symbol graph's data
             moduleName = graph.module.name
             return (moduleName, isMainSymbolGraph)
         } else {

--- a/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
@@ -139,7 +139,20 @@ extension GraphCollector {
         let isMainSymbolGraph = !url.lastPathComponent.contains("@") && !graph.module.isVirtual
 
         let moduleName: String
-        if isMainSymbolGraph {
+        if isMainSymbolGraph || graph.module.bystanders != nil {
+            // graph.module.bystanders exist with cross-import overlays, and we return the module name
+            // from the data in that graph, rather than trying to extract it from the filename,
+            // but it isn't considered a "primary" graph.
+
+            // A cross-import overlays is a distinct module that references a “declaring module”
+            // (the module it is considered to be a part of) and one or more “bystander modules”
+            // (modules that must be imported alongside the declaring module for the overlay to be available)
+            // it allows a module to declare extensions to another module without having to import it
+            // directly, like how MapKit adds a SwiftUI view but doesn’t actually import SwiftUI itself.
+            // when a symbol graph is requested for a cross-import overlay module, it is treated as
+            // an extension symbol graph for the declaring module so that the symbols can be folded into
+            // there.
+
             // For main symbol graphs, get the module name from the symbol graph's data
             moduleName = graph.module.name
             return (moduleName, isMainSymbolGraph)

--- a/Tests/SymbolKitTests/UnifiedGraph/CrossImportOverlaySymbolGraphs.swift
+++ b/Tests/SymbolKitTests/UnifiedGraph/CrossImportOverlaySymbolGraphs.swift
@@ -1,0 +1,756 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+struct CrossImportOverlaySymbolGraphs {
+    // example content from the Swift compiler tests that validate
+    // symbolgraph extraction from import-overlays:
+    // `test/SymbolGraph/Module/CrossImport.swift`
+    
+    // `A.symbols.json`
+    static func base() -> String {
+        """
+        {
+          "metadata": {
+            "formatVersion": {
+              "major": 0,
+              "minor": 6,
+              "patch": 0
+            },
+            "generator": "Swift version 6.2-dev (LLVM 22c18a5d2eb92f4, Swift 694274204ba65e0)"
+          },
+          "module": {
+            "name": "A",
+            "platform": {
+              "architecture": "arm64",
+              "vendor": "apple",
+              "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                  "major": 13,
+                  "minor": 0
+                }
+              }
+            }
+          },
+          "symbols": [
+            {
+              "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+              },
+              "identifier": {
+                "precise": "s:1AAAV",
+                "interfaceLanguage": "swift"
+              },
+              "pathComponents": [
+                "A"
+              ],
+              "names": {
+                "title": "A",
+                "navigator": [
+                  {
+                    "kind": "identifier",
+                    "spelling": "A"
+                  }
+                ],
+                "subHeading": [
+                  {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                  },
+                  {
+                    "kind": "text",
+                    "spelling": " "
+                  },
+                  {
+                    "kind": "identifier",
+                    "spelling": "A"
+                  }
+                ]
+              },
+              "declarationFragments": [
+                {
+                  "kind": "keyword",
+                  "spelling": "struct"
+                },
+                {
+                  "kind": "text",
+                  "spelling": " "
+                },
+                {
+                  "kind": "identifier",
+                  "spelling": "A"
+                }
+              ],
+              "accessLevel": "public"
+            },
+            {
+              "kind": {
+                "identifier": "swift.property",
+                "displayName": "Instance Property"
+              },
+              "identifier": {
+                "precise": "s:1AAAV1xSivp",
+                "interfaceLanguage": "swift"
+              },
+              "pathComponents": [
+                "A",
+                "x"
+              ],
+              "names": {
+                "title": "x",
+                "subHeading": [
+                  {
+                    "kind": "keyword",
+                    "spelling": "var"
+                  },
+                  {
+                    "kind": "text",
+                    "spelling": " "
+                  },
+                  {
+                    "kind": "identifier",
+                    "spelling": "x"
+                  },
+                  {
+                    "kind": "text",
+                    "spelling": ": "
+                  },
+                  {
+                    "kind": "typeIdentifier",
+                    "spelling": "Int",
+                    "preciseIdentifier": "s:Si"
+                  }
+                ]
+              },
+              "declarationFragments": [
+                {
+                  "kind": "keyword",
+                  "spelling": "var"
+                },
+                {
+                  "kind": "text",
+                  "spelling": " "
+                },
+                {
+                  "kind": "identifier",
+                  "spelling": "x"
+                },
+                {
+                  "kind": "text",
+                  "spelling": ": "
+                },
+                {
+                  "kind": "typeIdentifier",
+                  "spelling": "Int",
+                  "preciseIdentifier": "s:Si"
+                }
+              ],
+              "accessLevel": "public"
+            },
+            {
+              "kind": {
+                "identifier": "swift.init",
+                "displayName": "Initializer"
+              },
+              "identifier": {
+                "precise": "s:1AAAV1xABSi_tcfc",
+                "interfaceLanguage": "swift"
+              },
+              "pathComponents": [
+                "A",
+                "init(x:)"
+              ],
+              "names": {
+                "title": "init(x:)",
+                "subHeading": [
+                  {
+                    "kind": "keyword",
+                    "spelling": "init"
+                  },
+                  {
+                    "kind": "text",
+                    "spelling": "("
+                  },
+                  {
+                    "kind": "externalParam",
+                    "spelling": "x"
+                  },
+                  {
+                    "kind": "text",
+                    "spelling": ": "
+                  },
+                  {
+                    "kind": "typeIdentifier",
+                    "spelling": "Int",
+                    "preciseIdentifier": "s:Si"
+                  },
+                  {
+                    "kind": "text",
+                    "spelling": ")"
+                  }
+                ]
+              },
+              "functionSignature": {
+                "parameters": [
+                  {
+                    "name": "x",
+                    "declarationFragments": [
+                      {
+                        "kind": "identifier",
+                        "spelling": "x"
+                      },
+                      {
+                        "kind": "text",
+                        "spelling": ": "
+                      },
+                      {
+                        "kind": "typeIdentifier",
+                        "spelling": "Int",
+                        "preciseIdentifier": "s:Si"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "declarationFragments": [
+                {
+                  "kind": "keyword",
+                  "spelling": "init"
+                },
+                {
+                  "kind": "text",
+                  "spelling": "("
+                },
+                {
+                  "kind": "externalParam",
+                  "spelling": "x"
+                },
+                {
+                  "kind": "text",
+                  "spelling": ": "
+                },
+                {
+                  "kind": "typeIdentifier",
+                  "spelling": "Int",
+                  "preciseIdentifier": "s:Si"
+                },
+                {
+                  "kind": "text",
+                  "spelling": ")"
+                }
+              ],
+              "accessLevel": "public"
+            }
+          ],
+          "relationships": [
+            {
+              "kind": "memberOf",
+              "source": "s:1AAAV1xSivp",
+              "target": "s:1AAAV"
+            },
+            {
+              "kind": "memberOf",
+              "source": "s:1AAAV1xABSi_tcfc",
+              "target": "s:1AAAV"
+            }
+          ]
+        }
+        """
+    }
+    
+    // `_A_B@A.symbols.json`
+    static func overlaidA() -> String {
+        """
+        {
+          "metadata": {
+            "formatVersion": {
+              "major": 0,
+              "minor": 6,
+              "patch": 0
+            },
+            "generator": "Swift version 6.2-dev (LLVM 22c18a5d2eb92f4, Swift 694274204ba65e0)"
+          },
+          "module": {
+            "name": "A",
+            "bystanders": [
+              "B"
+            ],
+            "platform": {
+              "architecture": "arm64",
+              "vendor": "apple",
+              "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                  "major": 13,
+                  "minor": 0
+                }
+              }
+            }
+          },
+          "symbols": [
+            {
+              "kind": {
+                "identifier": "swift.extension",
+                "displayName": "Extension"
+              },
+              "identifier": {
+                "precise": "s:e:s:1AAAV4_A_BE12transmogrify1BAEVyF",
+                "interfaceLanguage": "swift"
+              },
+              "pathComponents": [
+                "A"
+              ],
+              "names": {
+                "title": "A",
+                "navigator": [
+                  {
+                    "kind": "identifier",
+                    "spelling": "A"
+                  }
+                ],
+                "subHeading": [
+                  {
+                    "kind": "keyword",
+                    "spelling": "extension"
+                  },
+                  {
+                    "kind": "text",
+                    "spelling": " "
+                  },
+                  {
+                    "kind": "typeIdentifier",
+                    "spelling": "A",
+                    "preciseIdentifier": "s:1AAAV"
+                  }
+                ]
+              },
+              "swiftExtension": {
+                "extendedModule": "A",
+                "typeKind": "swift.struct"
+              },
+              "declarationFragments": [
+                {
+                  "kind": "keyword",
+                  "spelling": "extension"
+                },
+                {
+                  "kind": "text",
+                  "spelling": " "
+                },
+                {
+                  "kind": "typeIdentifier",
+                  "spelling": "A",
+                  "preciseIdentifier": "s:1AAAV"
+                }
+              ],
+              "accessLevel": "public"
+            },
+            {
+              "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+              },
+              "identifier": {
+                "precise": "s:1AAAV4_A_BE12transmogrify1BAEVyF",
+                "interfaceLanguage": "swift"
+              },
+              "pathComponents": [
+                "A",
+                "transmogrify()"
+              ],
+              "names": {
+                "title": "transmogrify()",
+                "subHeading": [
+                  {
+                    "kind": "keyword",
+                    "spelling": "func"
+                  },
+                  {
+                    "kind": "text",
+                    "spelling": " "
+                  },
+                  {
+                    "kind": "identifier",
+                    "spelling": "transmogrify"
+                  },
+                  {
+                    "kind": "text",
+                    "spelling": "() -> "
+                  },
+                  {
+                    "kind": "typeIdentifier",
+                    "spelling": "B",
+                    "preciseIdentifier": "s:1BAAV"
+                  }
+                ]
+              },
+              "functionSignature": {
+                "returns": [
+                  {
+                    "kind": "typeIdentifier",
+                    "spelling": "B",
+                    "preciseIdentifier": "s:1BAAV"
+                  }
+                ]
+              },
+              "swiftExtension": {
+                "extendedModule": "A",
+                "typeKind": "swift.struct"
+              },
+              "declarationFragments": [
+                {
+                  "kind": "keyword",
+                  "spelling": "func"
+                },
+                {
+                  "kind": "text",
+                  "spelling": " "
+                },
+                {
+                  "kind": "identifier",
+                  "spelling": "transmogrify"
+                },
+                {
+                  "kind": "text",
+                  "spelling": "() -> "
+                },
+                {
+                  "kind": "typeIdentifier",
+                  "spelling": "B",
+                  "preciseIdentifier": "s:1BAAV"
+                }
+              ],
+              "accessLevel": "public"
+            },
+            {
+              "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+              },
+              "identifier": {
+                "precise": "s:4_A_B11LocalStructV",
+                "interfaceLanguage": "swift"
+              },
+              "pathComponents": [
+                "LocalStruct"
+              ],
+              "names": {
+                "title": "LocalStruct",
+                "navigator": [
+                  {
+                    "kind": "identifier",
+                    "spelling": "LocalStruct"
+                  }
+                ],
+                "subHeading": [
+                  {
+                    "kind": "keyword",
+                    "spelling": "struct"
+                  },
+                  {
+                    "kind": "text",
+                    "spelling": " "
+                  },
+                  {
+                    "kind": "identifier",
+                    "spelling": "LocalStruct"
+                  }
+                ]
+              },
+              "declarationFragments": [
+                {
+                  "kind": "keyword",
+                  "spelling": "struct"
+                },
+                {
+                  "kind": "text",
+                  "spelling": " "
+                },
+                {
+                  "kind": "identifier",
+                  "spelling": "LocalStruct"
+                }
+              ],
+              "accessLevel": "public"
+            },
+            {
+              "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+              },
+              "identifier": {
+                "precise": "s:4_A_B11LocalStructV8someFuncyyF",
+                "interfaceLanguage": "swift"
+              },
+              "pathComponents": [
+                "LocalStruct",
+                "someFunc()"
+              ],
+              "names": {
+                "title": "someFunc()",
+                "subHeading": [
+                  {
+                    "kind": "keyword",
+                    "spelling": "func"
+                  },
+                  {
+                    "kind": "text",
+                    "spelling": " "
+                  },
+                  {
+                    "kind": "identifier",
+                    "spelling": "someFunc"
+                  },
+                  {
+                    "kind": "text",
+                    "spelling": "()"
+                  }
+                ]
+              },
+              "functionSignature": {
+                "returns": [
+                  {
+                    "kind": "text",
+                    "spelling": "()"
+                  }
+                ]
+              },
+              "swiftExtension": {
+                "extendedModule": "_A_B",
+                "typeKind": "swift.struct"
+              },
+              "declarationFragments": [
+                {
+                  "kind": "keyword",
+                  "spelling": "func"
+                },
+                {
+                  "kind": "text",
+                  "spelling": " "
+                },
+                {
+                  "kind": "identifier",
+                  "spelling": "someFunc"
+                },
+                {
+                  "kind": "text",
+                  "spelling": "()"
+                }
+              ],
+              "accessLevel": "public"
+            }
+          ],
+          "relationships": [
+            {
+              "kind": "extensionTo",
+              "source": "s:e:s:1AAAV4_A_BE12transmogrify1BAEVyF",
+              "target": "s:1AAAV",
+              "targetFallback": "A.A"
+            },
+            {
+              "kind": "memberOf",
+              "source": "s:1AAAV4_A_BE12transmogrify1BAEVyF",
+              "target": "s:e:s:1AAAV4_A_BE12transmogrify1BAEVyF",
+              "targetFallback": "A.A"
+            },
+            {
+              "kind": "memberOf",
+              "source": "s:4_A_B11LocalStructV8someFuncyyF",
+              "target": "s:4_A_B11LocalStructV"
+            }
+          ]
+        }
+        """
+    }
+
+    // `_A_B@B.symbols.json`
+    static func overlaidB() -> String {
+        """
+        {
+          "metadata": {
+            "formatVersion": {
+              "major": 0,
+              "minor": 6,
+              "patch": 0
+            },
+            "generator": "Swift version 6.2-dev (LLVM 22c18a5d2eb92f4, Swift 694274204ba65e0)"
+          },
+          "module": {
+            "name": "A",
+            "bystanders": [
+              "B"
+            ],
+            "platform": {
+              "architecture": "arm64",
+              "vendor": "apple",
+              "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": {
+                  "major": 13,
+                  "minor": 0
+                }
+              }
+            }
+          },
+          "symbols": [
+            {
+              "kind": {
+                "identifier": "swift.extension",
+                "displayName": "Extension"
+              },
+              "identifier": {
+                "precise": "s:e:s:1BAAV4_A_BE14untransmogrify1AAEVyF",
+                "interfaceLanguage": "swift"
+              },
+              "pathComponents": [
+                "B"
+              ],
+              "names": {
+                "title": "B",
+                "navigator": [
+                  {
+                    "kind": "identifier",
+                    "spelling": "B"
+                  }
+                ],
+                "subHeading": [
+                  {
+                    "kind": "keyword",
+                    "spelling": "extension"
+                  },
+                  {
+                    "kind": "text",
+                    "spelling": " "
+                  },
+                  {
+                    "kind": "typeIdentifier",
+                    "spelling": "B",
+                    "preciseIdentifier": "s:1BAAV"
+                  }
+                ]
+              },
+              "swiftExtension": {
+                "extendedModule": "B",
+                "typeKind": "swift.struct"
+              },
+              "declarationFragments": [
+                {
+                  "kind": "keyword",
+                  "spelling": "extension"
+                },
+                {
+                  "kind": "text",
+                  "spelling": " "
+                },
+                {
+                  "kind": "typeIdentifier",
+                  "spelling": "B",
+                  "preciseIdentifier": "s:1BAAV"
+                }
+              ],
+              "accessLevel": "public"
+            },
+            {
+              "kind": {
+                "identifier": "swift.method",
+                "displayName": "Instance Method"
+              },
+              "identifier": {
+                "precise": "s:1BAAV4_A_BE14untransmogrify1AAEVyF",
+                "interfaceLanguage": "swift"
+              },
+              "pathComponents": [
+                "B",
+                "untransmogrify()"
+              ],
+              "names": {
+                "title": "untransmogrify()",
+                "subHeading": [
+                  {
+                    "kind": "keyword",
+                    "spelling": "func"
+                  },
+                  {
+                    "kind": "text",
+                    "spelling": " "
+                  },
+                  {
+                    "kind": "identifier",
+                    "spelling": "untransmogrify"
+                  },
+                  {
+                    "kind": "text",
+                    "spelling": "() -> "
+                  },
+                  {
+                    "kind": "typeIdentifier",
+                    "spelling": "A",
+                    "preciseIdentifier": "s:1AAAV"
+                  }
+                ]
+              },
+              "functionSignature": {
+                "returns": [
+                  {
+                    "kind": "typeIdentifier",
+                    "spelling": "A",
+                    "preciseIdentifier": "s:1AAAV"
+                  }
+                ]
+              },
+              "swiftExtension": {
+                "extendedModule": "B",
+                "typeKind": "swift.struct"
+              },
+              "declarationFragments": [
+                {
+                  "kind": "keyword",
+                  "spelling": "func"
+                },
+                {
+                  "kind": "text",
+                  "spelling": " "
+                },
+                {
+                  "kind": "identifier",
+                  "spelling": "untransmogrify"
+                },
+                {
+                  "kind": "text",
+                  "spelling": "() -> "
+                },
+                {
+                  "kind": "typeIdentifier",
+                  "spelling": "A",
+                  "preciseIdentifier": "s:1AAAV"
+                }
+              ],
+              "accessLevel": "public"
+            }
+          ],
+          "relationships": [
+            {
+              "kind": "extensionTo",
+              "source": "s:e:s:1BAAV4_A_BE14untransmogrify1AAEVyF",
+              "target": "s:1BAAV",
+              "targetFallback": "B.B"
+            },
+            {
+              "kind": "memberOf",
+              "source": "s:1BAAV4_A_BE14untransmogrify1AAEVyF",
+              "target": "s:e:s:1BAAV4_A_BE14untransmogrify1AAEVyF",
+              "targetFallback": "B.B"
+            }
+          ]
+        }
+        """
+    }
+}

--- a/Tests/SymbolKitTests/UnifiedGraph/GraphCollectorTests.swift
+++ b/Tests/SymbolKitTests/UnifiedGraph/GraphCollectorTests.swift
@@ -152,4 +152,39 @@ class GraphCollectorTests: XCTestCase {
         XCTAssertFalse(snippetIsMain)
         XCTAssertEqual("A", snippetName)
     }
+
+    func testModuleNameForImportOverlaySymbolGraph() throws {
+        // aligned with the name "A.symbols.json"
+        guard let jsonDataA = CrossImportOverlaySymbolGraphs.base().data(using: .utf8) else {
+            XCTFail("Invalid JSON in cross import overlay example data")
+            return
+        }
+        let a = try JSONDecoder().decode(SymbolGraph.self, from: jsonDataA)
+
+        let (name, isMain) = GraphCollector.moduleNameFor(a, at: .init(fileURLWithPath: "A.symbols.json"))
+        XCTAssertTrue(isMain)
+        XCTAssertEqual("A", name)
+
+        // aligned with the name "_A_B@A.symbols.json"
+        guard let jsonDataAatA = CrossImportOverlaySymbolGraphs.overlaidA().data(using: .utf8) else {
+            XCTFail("Invalid JSON in cross import overlay example data")
+            return
+        }
+        let a_At_A = try JSONDecoder().decode(SymbolGraph.self, from: jsonDataAatA)
+
+        let (extendedA, extendedAIsMain) = GraphCollector.moduleNameFor(a_At_A, at: .init(fileURLWithPath: "_A_B@A.symbols.json"))
+        XCTAssertFalse(extendedAIsMain)
+        XCTAssertEqual("A", extendedA)
+
+        // aligned with the name "_A_B@B.symbols.json"
+        guard let jsonDataAatB = CrossImportOverlaySymbolGraphs.overlaidB().data(using: .utf8) else {
+            XCTFail("Invalid JSON in cross import overlay example data")
+            return
+        }
+        let a_At_B = try JSONDecoder().decode(SymbolGraph.self, from: jsonDataAatB)
+
+        let (extendedB, extendedBIsMain) = GraphCollector.moduleNameFor(a_At_B, at: .init(fileURLWithPath: "_A_B@B.symbols.json"))
+        XCTAssertFalse(extendedBIsMain)
+        XCTAssertEqual("A", extendedB)
+    }
 }


### PR DESCRIPTION
Follow up from https://github.com/swiftlang/swift-docc/pull/1091/files#r2298429213 to address missing logic to accommodate a symbol graph from a cross-import overlay. The additional logic isn't yet matched with tests that verify the results in a loading scenario